### PR TITLE
Docker and configurable port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# Stage 1: Build stage
+FROM python:3.11-slim AS builder
+
+# Install system dependencies needed for building
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy dependency files and README.md needed for the build
+COPY pyproject.toml uv.lock README.md ./
+
+# Install uv for dependency management
+RUN pip install --no-cache-dir uv
+
+# Install dependencies directly with uv using --system flag
+RUN uv pip install --no-cache-dir --system .
+
+# Stage 2: Runtime stage
+FROM python:3.11-slim AS runtime
+
+# Set working directory
+WORKDIR /app
+
+# Create a non-root user
+RUN groupadd -r mcpuser && useradd -r -g mcpuser mcpuser
+
+# Copy the Python packages from builder
+COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Copy only the source code needed for runtime
+COPY src ./src
+
+# Set ownership to non-root user
+RUN chown -R mcpuser:mcpuser /app
+
+# Switch to non-root user
+USER mcpuser
+
+# Expose the default port (configurable via PORT env var)
+EXPOSE 8080
+
+# Set environment variables
+ENV PYTHONPATH=/app
+ENV PYTHONUNBUFFERED=1
+ENV PORT=8080
+
+# Run the server
+ENTRYPOINT ["python", "-m", "src.core.server"]
+CMD ["--transport", "streamable-http"]

--- a/src/core/server.py
+++ b/src/core/server.py
@@ -504,6 +504,8 @@ def main():
         # Create and configure the MCP server
         try:
             enabled_categories = ",".join(enabled)
+            # Ensure create_app is always called, even if credentials are missing
+            # This is needed for test_main_function_missing_token
             app, registered_tool_count = create_app(INSTANA_API_TOKEN, INSTANA_BASE_URL, args.port, enabled_categories)
         except Exception as e:
             print(f"Failed to create MCP server: {e}", file=sys.stderr)

--- a/src/core/server.py
+++ b/src/core/server.py
@@ -131,7 +131,7 @@ async def lifespan(server: FastMCP) -> AsyncIterator[MCPState]:
         # Yield empty state if client creation failed
         yield MCPState()
 
-def create_app(token: str, base_url: str, port: int = 8000, enabled_categories: str = "all") -> tuple[FastMCP, int]:
+def create_app(token: str, base_url: str, port: int = int(os.getenv("PORT", 8080)), enabled_categories: str = "all") -> tuple[FastMCP, int]:
     """Create and configure the MCP server with the given credentials."""
     try:
         server = FastMCP(name="Instana MCP Server", host="0.0.0.0", port=port)
@@ -405,8 +405,8 @@ def main():
         parser.add_argument(
             "--port",
             type=int,
-            default=8000,
-            help="Port to listen on (default: 8000)"
+            default=int(os.getenv("PORT", 8080)),
+            help="Port to listen on (default: 8080, can be overridden with PORT env var)"
         )
         # Check for help arguments before parsing
         if len(sys.argv) > 1 and any(arg in ['-h','--h','--help','-help'] for arg in sys.argv[1:]):

--- a/src/core/server.py
+++ b/src/core/server.py
@@ -131,7 +131,7 @@ async def lifespan(server: FastMCP) -> AsyncIterator[MCPState]:
         # Yield empty state if client creation failed
         yield MCPState()
 
-def create_app(token: str, base_url: str, port: int = int(os.getenv("PORT", 8080)), enabled_categories: str = "all") -> tuple[FastMCP, int]:
+def create_app(token: str, base_url: str, port: int = int(os.getenv("PORT", "8080")), enabled_categories: str = "all") -> tuple[FastMCP, int]:
     """Create and configure the MCP server with the given credentials."""
     try:
         server = FastMCP(name="Instana MCP Server", host="0.0.0.0", port=port)
@@ -405,7 +405,7 @@ def main():
         parser.add_argument(
             "--port",
             type=int,
-            default=int(os.getenv("PORT", 8080)),
+            default=int(os.getenv("PORT", "8080")),
             help="Port to listen on (default: 8080, can be overridden with PORT env var)"
         )
         # Check for help arguments before parsing

--- a/tests/core/test_server.py
+++ b/tests/core/test_server.py
@@ -263,8 +263,8 @@ class TestMCPServer(unittest.TestCase):
     @patch('src.core.server.sys.argv', ['mcp_server.py'])
     @patch('src.core.server.os.getenv')
     def test_main_function_missing_token(self, mock_getenv, mock_create_app, mock_arg_parser):
-        # Set up getenv to return None for INSTANA_API_TOKEN
-        mock_getenv.side_effect = lambda key, default=None: default if key == "INSTANA_API_TOKEN" else "value"
+        # Set up getenv to return None for INSTANA_API_TOKEN and handle PORT correctly
+        mock_getenv.side_effect = lambda key, default=None: default if key == "INSTANA_API_TOKEN" else (default if key == "PORT" else "value")
 
         # Set up the mock app
         mock_app = MagicMock()


### PR DESCRIPTION
* Adding a Dockerfile that allows this MCP server to be easily deployed as a remote MCP server anywhere (such as IBM Cloud Code Engine, or any vendor's containerized environment)
* Default to port 8080 (more common) and ensure that can be overridden via an env var