### PR TITLE
fix: Use correct pagination model for infrastructure analyze queries

### DIFF
--- a/src/infrastructure/infrastructure_analyze_new.py
+++ b/src/infrastructure/infrastructure_analyze_new.py
@@ -243,7 +243,7 @@ class InfrastructureAnalyzeOption2(BaseInstanaClient):
         group_by = selections.get("groupBy", [])
         order = selections.get("order")  # Optional: {"by": "metric_name", "direction": "ASC|DESC"}
         time_range = selections.get("timeRange", "1h")  # Default to 1 hour
-        pagination = selections.get("pagination", {})  # Optional: {"page": 1, "pageSize": 20} or {"offset": 0, "limit": 20}
+        pagination = selections.get("pagination", {})  # Optional: {"pageSize": 20, "cursor": {...}} or {"limit": 20, "cursor": {...}}
 
         # Ensure metrics is a list
         if not isinstance(metrics, list):
@@ -270,7 +270,9 @@ class InfrastructureAnalyzeOption2(BaseInstanaClient):
 
         # Build payload using payload compiler
         # For PoC, we'll build a simple payload directly
-        from instana_client.models.cursor_pagination import CursorPagination
+        from instana_client.models.cursor_pagination_infra_explore_cursor import (
+            CursorPaginationInfraExploreCursor,
+        )
         from instana_client.models.get_infrastructure_groups_query import (
             GetInfrastructureGroupsQuery,
         )
@@ -455,31 +457,24 @@ class InfrastructureAnalyzeOption2(BaseInstanaClient):
                 logger.info(f"Built Order: by={order_by}, direction={order_direction}")
 
         # Build pagination object
-        # Supports pagination formats: {"page": 1, "pageSize": 20} or {"offset": 0, "limit": 20}
+        # Supports pagination formats: {"pageSize": 20, "cursor": "..."} or {"limit": 20, "cursor": "..."}
         page_size = 50  # Default
-        offset = None
+        cursor = None
 
         if pagination and isinstance(pagination, dict):
             # Handle pageSize or limit
             page_size = pagination.get("pageSize") or pagination.get("limit", 50)
 
-            # Handle page number (convert to offset)
-            page = pagination.get("page")
-            if page is not None and page > 0:
-                offset = (page - 1) * page_size
-                logger.info(f"Converted page {page} to offset {offset}")
+            # Handle cursor for pagination
+            cursor = pagination.get("cursor")
 
-            # Handle direct offset
-            if "offset" in pagination:
-                offset = pagination.get("offset", 0)
+            logger.info(f"Pagination: pageSize={page_size}, cursor={cursor}")
 
-            logger.info(f"Pagination: pageSize={page_size}, offset={offset}")
-
-        # Build CursorPagination object
-        if offset is not None and offset > 0:
-            cursor_pagination = CursorPagination(retrieval_size=page_size, offset=offset)
+        # Build CursorPaginationInfraExploreCursor object
+        if cursor is not None:
+            cursor_pagination = CursorPaginationInfraExploreCursor(retrieval_size=page_size, cursor=cursor)
         else:
-            cursor_pagination = CursorPagination(retrieval_size=page_size)
+            cursor_pagination = CursorPaginationInfraExploreCursor(retrieval_size=page_size)
 
         # Build TimeFrame object - supports both relative and absolute time ranges
         if to_timestamp is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -1106,7 +1106,7 @@ wheels = [
 
 [[package]]
 name = "instana-client"
-version = "1.0.2"
+version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -1114,9 +1114,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/8e/170c32428902538b994031ea0bec694d2f113798d81cd7fb50e0961625f2/instana_client-1.0.2.tar.gz", hash = "sha256:fca60b61d0b0a13520373312e2cce8d06be4c732c5824d3fd785234cbc68cbde", size = 534634, upload-time = "2025-12-05T11:43:06.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/06/8ee9833b80d6e1bea1b9d3da868afee97db8a2070b0ad2440c5cbb6d8a01/instana_client-1.0.3.tar.gz", hash = "sha256:3471b24bf8c2bfb5726e0be35f0fd4a31976f61b3b3d2068ccf726436f796c2c", size = 541612, upload-time = "2026-02-04T14:25:02.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/11/b7dc90fe7ff361528aa9afe314f5c4f86b3eeb04748951168bae3544585e/instana_client-1.0.2-py3-none-any.whl", hash = "sha256:e799ef5a754168d9581b350097a90aacfe80ae49a2819732edb2b1513124f1df", size = 1151072, upload-time = "2025-12-05T11:43:02.072Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e3/69ac96b06c05317354aa576f59ed541d8d6e10f7af07b183bc113315e75b/instana_client-1.0.3-py3-none-any.whl", hash = "sha256:8c275c48a687621dc698bbc2006ecbd7ae6003a6fb65467f3231662d47eced08", size = 1158935, upload-time = "2026-02-04T14:24:59.769Z" },
 ]
 
 [[package]]
@@ -1520,7 +1520,7 @@ wheels = [
 
 [[package]]
 name = "mcp-instana"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -1548,7 +1548,7 @@ dev = [
 requires-dist = [
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.10.1" },
     { name = "fastmcp", specifier = "==2.13.0" },
-    { name = "instana-client", specifier = "==1.0.2" },
+    { name = "instana-client", specifier = "==1.0.3" },
     { name = "lazy-imports" },
     { name = "mcp" },
     { name = "pydantic", specifier = "==2.11.7" },


### PR DESCRIPTION
## Problem

The infrastructure analyze tool was failing with a Pydantic validation error when creating queries.  
This occurred for otherwise valid payloads, preventing the tool from functioning correctly.

## Root Cause

The wrong pagination model (`CursorPagination`) was being used when building
`GetInfrastructureQuery` objects. Infrastructure explore queries require
`CursorPaginationInfraExploreCursor` as per the Instana SDK.

## Changes

- **Updated pagination model**: Switched from `CursorPagination` to
  `CursorPaginationInfraExploreCursor`
- **Updated pagination logic**: Replaced `offset`-based pagination with
  `cursor`-based pagination (dict) to match the correct SDK model
- **Updated documentation**: Fixed inline comments to reflect the correct
  pagination format
