### PR TITLE
fix: Properly convert nested request parameters to SDK model types in get_grouped_calls_metrics

### DIFF
--- a/src/application/application_call_group.py
+++ b/src/application/application_call_group.py
@@ -135,26 +135,56 @@ class ApplicationCallGroupMCPTools(BaseInstanaClient):
                     "groupbyTagEntity": "DESTINATION"
                 }
 
-            # Create the GetCallGroups object with ONLY group and metrics
-            # The SDK model only accepts these two parameters
-            query_params = {}
+            # Build complete request body with all parameters
+            # IMPORTANT: SDK expects camelCase keys (aliases), not snake_case
+            request_body = {}
             if group:
-                query_params["group"] = group
+                request_body["group"] = group
             if metrics:
-                query_params["metrics"] = metrics
+                request_body["metrics"] = metrics
+            if tag_filter_expression:
+                request_body["tagFilterExpression"] = tag_filter_expression  # camelCase!
+            if time_frame:
+                request_body["timeFrame"] = time_frame  # camelCase!
+            if pagination:
+                request_body["pagination"] = pagination
+            if order:
+                request_body["order"] = order
+            if include_internal is not None:
+                request_body["includeInternal"] = include_internal  # camelCase!
+            if include_synthetic is not None:
+                request_body["includeSynthetic"] = include_synthetic  # camelCase!
 
-            logger.debug(f"Creating GetCallGroups with params: {query_params}")
-            get_call_groups = GetCallGroups(**query_params)
+            # 🔍 DEBUG: Log the request body BEFORE SDK conversion
+            logger.info("=" * 80)
+            logger.info("📤 REQUEST BODY DEBUG - BEFORE SDK CONVERSION")
+            logger.info("=" * 80)
+            logger.info(f"Request Body Type: {type(request_body)}")
+            logger.info(f"Request Body Keys: {request_body.keys()}")
+            logger.info(f"Full Request Body: {request_body}")
+            logger.info("=" * 80)
+
+            # Use from_dict to properly convert nested objects to SDK model types
+            logger.debug(f"Creating GetCallGroups from request_body: {request_body}")
+            get_call_groups = GetCallGroups.from_dict(request_body)
             logger.debug("Successfully created GetCallGroups object")
 
+            # 🔍 DEBUG: Log the SDK object AFTER conversion
+            logger.info("=" * 80)
+            logger.info("📦 SDK OBJECT DEBUG - AFTER CONVERSION")
+            logger.info("=" * 80)
+            if hasattr(get_call_groups, 'to_dict'):
+                sdk_dict = get_call_groups.to_dict()
+                logger.info(f"SDK Object as Dict: {sdk_dict}")
+            logger.info("=" * 80)
+
             # Call the get_call_group method from the SDK
-            # Note: Other parameters like time_frame, tag_filter_expression, etc.
-            # might need to be passed as separate parameters to the API call
-            # For now, following the exact pattern from application_analyze.py
             logger.debug("Calling get_call_group with GetCallGroups object")
             result = api_client.get_call_group(
-                get_call_groups=get_call_groups
+                get_call_groups=get_call_groups,
+                fill_time_series=fill_time_series
             )
+
 
             # Convert the result to a dictionary
             if hasattr(result, 'to_dict'):

--- a/src/application/application_call_group.py
+++ b/src/application/application_call_group.py
@@ -156,13 +156,13 @@ class ApplicationCallGroupMCPTools(BaseInstanaClient):
                 request_body["includeSynthetic"] = include_synthetic  # camelCase!
 
             # 🔍 DEBUG: Log the request body BEFORE SDK conversion
-            logger.info("=" * 80)
-            logger.info("📤 REQUEST BODY DEBUG - BEFORE SDK CONVERSION")
-            logger.info("=" * 80)
-            logger.info(f"Request Body Type: {type(request_body)}")
-            logger.info(f"Request Body Keys: {request_body.keys()}")
-            logger.info(f"Full Request Body: {request_body}")
-            logger.info("=" * 80)
+            logger.debug("=" * 80)
+            logger.debug("📤 REQUEST BODY DEBUG - BEFORE SDK CONVERSION")
+            logger.debug("=" * 80)
+            logger.debug(f"Request Body Type: {type(request_body)}")
+            logger.debug(f"Request Body Keys: {request_body.keys()}")
+            logger.debug(f"Full Request Body: {request_body}")
+            logger.debug("=" * 80)
 
             # Use from_dict to properly convert nested objects to SDK model types
             logger.debug(f"Creating GetCallGroups from request_body: {request_body}")
@@ -170,13 +170,13 @@ class ApplicationCallGroupMCPTools(BaseInstanaClient):
             logger.debug("Successfully created GetCallGroups object")
 
             # 🔍 DEBUG: Log the SDK object AFTER conversion
-            logger.info("=" * 80)
-            logger.info("📦 SDK OBJECT DEBUG - AFTER CONVERSION")
-            logger.info("=" * 80)
+            logger.debug("=" * 80)
+            logger.debug("📦 SDK OBJECT DEBUG - AFTER CONVERSION")
+            logger.debug("=" * 80)
             if hasattr(get_call_groups, 'to_dict'):
                 sdk_dict = get_call_groups.to_dict()
-                logger.info(f"SDK Object as Dict: {sdk_dict}")
-            logger.info("=" * 80)
+                logger.debug(f"SDK Object as Dict: {sdk_dict}")
+            logger.debug("=" * 80)
 
             # Call the get_call_group method from the SDK
             logger.debug("Calling get_call_group with GetCallGroups object")
@@ -194,23 +194,23 @@ class ApplicationCallGroupMCPTools(BaseInstanaClient):
                 result_dict = result
 
             # 🔍 DEBUG: Log the API response structure and data
-            logger.info("=" * 80)
-            logger.info("📥 INSTANA API RESPONSE DEBUG - CALL GROUPS")
-            logger.info("=" * 80)
-            logger.info(f"Response Type: {type(result_dict)}")
-            logger.info(f"Response Keys: {result_dict.keys() if isinstance(result_dict, dict) else 'N/A'}")
+            logger.debug("=" * 80)
+            logger.debug("📥 INSTANA API RESPONSE DEBUG - CALL GROUPS")
+            logger.debug("=" * 80)
+            logger.debug(f"Response Type: {type(result_dict)}")
+            logger.debug(f"Response Keys: {result_dict.keys() if isinstance(result_dict, dict) else 'N/A'}")
 
             # Log detailed structure for each group
             if isinstance(result_dict, dict) and 'items' in result_dict:
-                logger.info(f"Number of groups: {len(result_dict['items'])}")
+                logger.debug(f"Number of groups: {len(result_dict['items'])}")
                 for idx, item in enumerate(result_dict['items'][:3]):  # Log first 3 items
-                    logger.info(f"\nGroup {idx}:")
-                    logger.info(f"  Keys: {item.keys() if isinstance(item, dict) else 'N/A'}")
+                    logger.debug(f"\nGroup {idx}:")
+                    logger.debug(f"  Keys: {item.keys() if isinstance(item, dict) else 'N/A'}")
                     if isinstance(item, dict):
                         if 'metrics' in item:
-                            logger.info(f"  Metrics: {item['metrics'].keys() if isinstance(item['metrics'], dict) else item['metrics']}")
+                            logger.debug(f"  Metrics: {item['metrics'].keys() if isinstance(item['metrics'], dict) else item['metrics']}")
 
-            logger.info("=" * 80)
+            logger.debug("=" * 80)
             logger.debug(f"Full Result: {result_dict}")
 
             # Post-process the response to make it more LLM-friendly

--- a/src/core/smart_router_tool.py
+++ b/src/core/smart_router_tool.py
@@ -198,16 +198,30 @@ class SmartRouterMCPTool(BaseInstanaClient):
                 "valid_operations": ["application"]
             }
 
-        # Extract parameters
+        # Extract parameters - support both camelCase and snake_case
         query = params.get("query", "")
-        time_frame = params.get("time_frame")
+        time_frame = params.get("time_frame") or params.get("timeFrame")
         metrics = params.get("metrics")
-        tag_filter_expression = params.get("tag_filter_expression")
+        tag_filter_expression = params.get("tag_filter_expression") or params.get("tagFilterExpression")
         group = params.get("group")
         order = params.get("order")
         pagination = params.get("pagination")
-        include_internal = params.get("include_internal")
-        include_synthetic = params.get("include_synthetic")
+        include_internal = params.get("include_internal") or params.get("includeInternal")
+        include_synthetic = params.get("include_synthetic") or params.get("includeSynthetic")
+
+        # 🔍 DEBUG: Log extracted parameters
+        logger.debug("=" * 80)
+        logger.debug("📤 SMART ROUTER - EXTRACTED PARAMS")
+        logger.debug("=" * 80)
+        logger.debug(f"time_frame: {time_frame}")
+        logger.debug(f"metrics: {metrics}")
+        logger.debug(f"tag_filter_expression: {tag_filter_expression}")
+        logger.debug(f"group: {group}")
+        logger.debug(f"order: {order}")
+        logger.debug(f"pagination: {pagination}")
+        logger.debug(f"include_internal: {include_internal}")
+        logger.debug(f"include_synthetic: {include_synthetic}")
+        logger.debug("=" * 80)
 
         # Route to Application Call Group Metrics
         logger.info("Routing to Application Call Group Metrics")


### PR DESCRIPTION
## Problem

The `get_grouped_calls_metrics` method was not properly converting nested request parameters into SDK model types. As a result, fields such as `tagFilterExpression`, `timeFrame`, and others were being dropped before reaching the Instana API.

This caused filters and time ranges to be ignored in queries.

## Root Cause

The request body was manually constructed using a partial dict and passed directly to `GetCallGroups(**query_params)`. 

This led to:
- Nested dictionaries not being converted into proper SDK model objects
- Several supported parameters being ignored
- Mismatch between snake_case parameters and the SDK’s expected camelCase field aliases

## Changes

- Switched to using `GetCallGroups.from_dict()` to ensure proper recursive model conversion
- Updated request body construction to use SDK-compatible camelCase keys
- Included all supported parameters (e.g., `tagFilterExpression`, `timeFrame`, pagination, ordering, etc.)
- Added support in the smart router for both snake_case and camelCase parameter inputs
- Added debug logging to improve traceability
