### PR TITLE
feat: Add `--env` flag for setting environment variables via CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.8.1
+-  **Fix:** Add `--env` flag for setting environment variables via CLI
+
 ### 0.8.0
 
 -   **Enhancement:** Introduced separate unified smart router to handle all automation and event related operations, improving routing consistency and maintainability.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ uv run src/core/server.py [OPTIONS]
 
 **Available Options:**
 - `--transport <mode>`: Transport mode (choices: `streamable-http`, `stdio`)
+- `--env KEY=VALUE`: Set environment variable (can be repeated for multiple variables, e.g., `--env INSTANA_BASE_URL=https://... --env INSTANA_API_TOKEN=...`)
 - `--debug`: Enable debug mode with additional logging
 - `--log-level <level>`: Set the logging level (choices: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`)
 - `--tools <categories>`: Comma-separated list of tool categories to enable (e.g., infra,app,events,website). Enabling a category will also enable its related prompts. For example: `--tools infra` enables the infra tools and all infra-related prompts.
@@ -279,7 +280,7 @@ uv run src/core/server.py --transport streamable-http --log-level DEBUG --tools 
 #### Using CLI (PyPI Installation)
 
 ```bash
-# Set environment variables first
+# Option 1: Set environment variables first
 export INSTANA_BASE_URL="https://your-instana-instance.instana.io"
 export INSTANA_API_TOKEN="your_instana_api_token"
 
@@ -288,12 +289,18 @@ mcp-instana
 
 # Or explicitly specify stdio mode
 mcp-instana --transport stdio
+
+# Option 2: Use --env flag to set environment variables directly
+mcp-instana --env INSTANA_BASE_URL=https://your-instana-instance.instana.io --env INSTANA_API_TOKEN=your_instana_api_token
+
+# Or with explicit stdio mode
+mcp-instana --transport stdio --env INSTANA_BASE_URL=https://your-instana-instance.instana.io --env INSTANA_API_TOKEN=your_instana_api_token
 ```
 
 #### Using Development Installation
 
 ```bash
-# Set environment variables first
+# Option 1: Set environment variables first
 export INSTANA_BASE_URL="https://your-instana-instance.instana.io"
 export INSTANA_API_TOKEN="your_instana_api_token"
 
@@ -302,12 +309,19 @@ uv run src/core/server.py
 
 # Or explicitly specify stdio mode
 uv run src/core/server.py --transport stdio
+
+# Option 2: Use --env flag to set environment variables directly
+uv run src/core/server.py --env INSTANA_BASE_URL=https://your-instana-instance.instana.io --env INSTANA_API_TOKEN=your_instana_api_token
+
+# Or with explicit stdio mode
+uv run src/core/server.py --transport stdio --env INSTANA_BASE_URL=https://your-instana-instance.instana.io --env INSTANA_API_TOKEN=your_instana_api_token
 ```
 
 **Key Features of Stdio Mode:**
-- Uses environment variables for authentication
+- Uses environment variables for authentication (can be set via `export` or `--env` flag)
 - Direct communication via stdin/stdout
 - Required for certain MCP client configurations
+- The `--env` flag provides a convenient way to set credentials without modifying shell environment
 
 ### Tool Categories
 
@@ -438,6 +452,7 @@ get me all endpoints from Instana
 
 **Configuration using CLI (PyPI Installation - Recommended):**
 
+**Option 1: Using environment variables in config:**
 ```json
 {
   "mcpServers": {
@@ -453,10 +468,27 @@ get me all endpoints from Instana
 }
 ```
 
+**Option 2: Using --env flag (alternative method):**
+```json
+{
+  "mcpServers": {
+    "Instana MCP Server": {
+      "command": "mcp-instana",
+      "args": [
+        "--transport", "stdio",
+        "--env", "INSTANA_BASE_URL=https://your-instana-instance.instana.io",
+        "--env", "INSTANA_API_TOKEN=your_instana_api_token"
+      ]
+    }
+  }
+}
+```
+
 **Note:** If you encounter "command not found" errors, use the full path to mcp-instana. Find it with `which mcp-instana` and use that path instead.
 
 **Configuration using Development Installation:**
 
+**Option 1: Using environment variables in config:**
 ```json
 {
   "mcpServers": {
@@ -476,6 +508,25 @@ get me all endpoints from Instana
   }
 }
 ```
+
+**Option 2: Using --env flag (alternative method):**
+```json
+{
+  "mcpServers": {
+    "Instana MCP Server": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "<path-to-mcp-instana-folder>",
+        "run",
+        "src/core/server.py",
+        "--env", "INSTANA_BASE_URL=https://your-instana-instance.instana.io",
+        "--env", "INSTANA_API_TOKEN=your_instana_api_token"
+      ]
+    }
+  }
+}
+```
 ### Kiro Setup
 
 Kiro is an agentic IDE, not an extension that can be downloaded into VS Code or some other IDE.
@@ -491,7 +542,9 @@ Kiro is an agentic IDE, not an extension that can be downloaded into VS Code or 
 **Step 4: Select the Edit Config icon in the top right corner of the MCP Servers section.**
 ![alt text](./images/edir-kiro-config.png)
 
-**Step 5: Open the MCP server configuration file (mcp.json), similar to how it works in Claude, and update it with your server's name, commands, and headers as shown in the image below.**
+**Step 5: Open the MCP server configuration file (mcp.json) and configure it based on your preferred transport mode:**
+
+#### Streamable HTTP Mode (Recommended for Kiro)
 
 ```json
 {
@@ -499,10 +552,49 @@ Kiro is an agentic IDE, not an extension that can be downloaded into VS Code or 
     "Instana MCP Server": {
       "command": "npx",
       "args": [
-        "mcp-remote", "<YOUR_MCP_PORT>/mcp",
+        "mcp-remote", "http://0.0.0.0:8080/mcp/",
         "--allow-http",
-        "--header", "instana-base-url: <INSTANA_BASE_URL>",
-        "--header", "instana-api-token: <INSTANA_API_TOKEN>"
+        "--header", "instana-base-url: https://your-instana-instance.instana.io",
+        "--header", "instana-api-token: your_instana_api_token"
+      ]
+    }
+  }
+}
+```
+
+**Note:** Make sure to start the MCP server in streamable-http mode before using this configuration:
+```bash
+mcp-instana --transport streamable-http
+```
+
+#### Stdio Mode
+
+**Option 1: Using environment variables in config:**
+```json
+{
+  "mcpServers": {
+    "Instana MCP Server": {
+      "command": "mcp-instana",
+      "args": ["--transport", "stdio"],
+      "env": {
+        "INSTANA_BASE_URL": "https://your-instana-instance.instana.io",
+        "INSTANA_API_TOKEN": "your_instana_api_token"
+      }
+    }
+  }
+}
+```
+
+**Option 2: Using --env flag (alternative method):**
+```json
+{
+  "mcpServers": {
+    "Instana MCP Server": {
+      "command": "mcp-instana",
+      "args": [
+        "--transport", "stdio",
+        "--env", "INSTANA_BASE_URL=https://your-instana-instance.instana.io",
+        "--env", "INSTANA_API_TOKEN=your_instana_api_token"
       ]
     }
   }
@@ -567,6 +659,7 @@ You can directly create or update `.vscode/mcp.json` with the following configur
 
 Create `.vscode/mcp.json` in your project root:
 
+**Option 1: Using environment variables in config:**
 ```json:.vscode/mcp.json
 {
   "servers": {
@@ -582,10 +675,27 @@ Create `.vscode/mcp.json` in your project root:
 }
 ```
 
+**Option 2: Using --env flag (alternative method):**
+```json:.vscode/mcp.json
+{
+  "servers": {
+    "Instana MCP Server": {
+      "command": "mcp-instana",
+      "args": [
+        "--transport", "stdio",
+        "--env", "INSTANA_BASE_URL=https://your-instana-instance.instana.io",
+        "--env", "INSTANA_API_TOKEN=your_instana_api_token"
+      ]
+    }
+  }
+}
+```
+
 **Using Development Installation:**
 
 Create `.vscode/mcp.json` in your project root:
 
+**Option 1: Using environment variables in config:**
 ```json:.vscode/mcp.json
 {
   "servers": {
@@ -601,6 +711,25 @@ Create `.vscode/mcp.json` in your project root:
         "INSTANA_BASE_URL": "https://your-instana-instance.instana.io",
         "INSTANA_API_TOKEN": "your_instana_api_token"
       }
+    }
+  }
+}
+```
+
+**Option 2: Using --env flag (alternative method):**
+```json:.vscode/mcp.json
+{
+  "servers": {
+    "Instana MCP Server": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/absolute/path/to/your/project/mcp-instana",
+        "run",
+        "src/core/server.py",
+        "--env", "INSTANA_BASE_URL=https://your-instana-instance.instana.io",
+        "--env", "INSTANA_API_TOKEN=your_instana_api_token"
+      ]
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-instana"
-version = "0.8.0"
+version = "0.8.1"
 description = "MCP server for Instana"
 authors = [
     {name = "Elina Priyadarshinee", email = "Elina.priyadarshinee1@ibm.com"},

--- a/src/core/server.py
+++ b/src/core/server.py
@@ -394,14 +394,11 @@ def main():
             help="Port to listen on (default: 8080, can be overridden with PORT env var)"
         )
         parser.add_argument(
-            "--api-token",
-            type=str,
-            help="Instana API token (overrides INSTANA_API_TOKEN env var)"
-        )
-        parser.add_argument(
-            "--base-url",
-            type=str,
-            help="Instana base URL (overrides INSTANA_BASE_URL env var)"
+            "--env",
+            action="append",
+            metavar="KEY=VALUE",
+            default=None,
+            help="Set environment variable (e.g. --env INSTANA_BASE_URL=https://... --env INSTANA_API_TOKEN=...). Can be repeated."
         )
         # Check for help arguments before parsing
         if len(sys.argv) > 1 and any(arg in ['-h','--h','--help','-help'] for arg in sys.argv[1:]):
@@ -430,6 +427,17 @@ def main():
                 sys.exit(0)  # Still exit with 0 for help
 
         args = parser.parse_args()
+
+        # Apply --env KEY=VALUE overrides (e.g. INSTANA_BASE_URL, INSTANA_API_TOKEN)
+        if args.env:
+            for env_spec in args.env:
+                if "=" in env_spec:
+                    key, _, value = env_spec.partition("=")
+                    key = key.strip()
+                    if key:
+                        os.environ[key] = value
+                else:
+                    logger.warning("Ignoring malformed --env (expected KEY=VALUE): %s", env_spec)
 
         # Set log level based on command line arguments
         if args.debug:
@@ -488,9 +496,10 @@ def main():
                 f"Total enabled tools: {len(enabled_tool_classes)}"
             )
 
-        # Get credentials from command line args or environment variables
-        INSTANA_API_TOKEN = args.api_token if args.api_token else os.getenv("INSTANA_API_TOKEN", "")
-        INSTANA_BASE_URL = args.base_url if args.base_url else os.getenv("INSTANA_BASE_URL", "")
+        # Get credentials from environment variables for stdio mode
+        INSTANA_API_TOKEN, INSTANA_BASE_URL = get_instana_credentials()
+        logger.debug(f"INSTANA_API_TOKEN: {INSTANA_API_TOKEN}")
+        logger.debug(f"INSTANA_BASE_URL: {INSTANA_BASE_URL}")
 
         if args.transport == "stdio" or args.transport is None:
             if not validate_credentials(INSTANA_API_TOKEN, INSTANA_BASE_URL):

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -19,7 +19,7 @@ try:
     __version__ = version("mcp-instana")
 except Exception:
     # Fallback version if package metadata is not available
-    __version__ = "0.3.1"
+    __version__ = "0.8.1"
 
 # Registry to store all tools
 MCP_TOOLS = {}

--- a/uv.lock
+++ b/uv.lock
@@ -1520,7 +1520,7 @@ wheels = [
 
 [[package]]
 name = "mcp-instana"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Overview
This PR introduces a new `--env` command-line flag that allows users to pass environment variables directly when starting the MCP server.

This improves reliability for users running the server in **stdio mode** (e.g., via Claude Desktop, VS Code Copilot, or other MCP clients), where traditional environment variables or `.env` files may not always be correctly inherited.

---

## Problem
Some users installing the package from PyPI reported that environment variables such as:

- `INSTANA_BASE_URL`
- `INSTANA_API_TOKEN`

were not always picked up when launching the server through MCP clients using stdio transport. This caused the server to start successfully but fail to authenticate with Instana APIs.

---

## Solution
Added support for a new CLI argument: --env KEY=VALUE
This flag can be provided multiple times and directly sets variables in `os.environ` before credential resolution.

Example:

```bash
mcp-instana \
  --env INSTANA_BASE_URL=https://your-instance.instana.io \
  --env INSTANA_API_TOKEN=your_token