### PR TITLE
feat: Enable get_trace_details operation with file output and datetime conversion

### DIFF
--- a/src/application/application_analyze.py
+++ b/src/application/application_analyze.py
@@ -145,65 +145,65 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
     #     title="Get Trace Details",
     #     annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False)
     # )
-    # @with_header_auth(ApplicationAnalyzeApi)
-    # async def get_trace_details(
-    #     self,
-    #     id: str,
-    #     retrievalSize: Optional[int] = None,
-    #     offset: Optional[int] = None,
-    #     ingestionTime: Optional[int] = None,
-    #     ctx=None,
-    #     api_client=None
-    # ) -> Dict[str, Any]:
-    #     """
-    #     Get details of a specific trace.
-    #     This tool is to retrive comprehensive details of a particular trace.
-    #     Args:
-    #         id (str): The ID of the trace.
-    #         retrievalSize (Optional[int]):The number of records to retrieve in a single request.
-    #                                     Minimum value is 1 and maximum value is 10000.
-    #         offset (Optional[int]): The number of records to be skipped from the ingestionTime.
-    #         ingestionTime (Optional[int]): The timestamp indicating the starting point from which data was ingested.
-    #         ctx: Optional context for the request.
-    #     Returns:
-    #         Dict[str, Any]: Details of the specified trace.
-    #     """
+    @with_header_auth(ApplicationAnalyzeApi)
+    async def get_trace_details(
+        self,
+        id: str,
+        retrievalSize: Optional[int] = None,
+        offset: Optional[int] = None,
+        ingestionTime: Optional[int] = None,
+        ctx=None,
+        api_client=None
+    ) -> Dict[str, Any]:
+        """
+        Get details of a specific trace.
+        This tool is to retrive comprehensive details of a particular trace.
+        Args:
+            id (str): The ID of the trace.
+            retrievalSize (Optional[int]):The number of records to retrieve in a single request.
+                                        Minimum value is 1 and maximum value is 10000.
+            offset (Optional[int]): The number of records to be skipped from the ingestionTime.
+            ingestionTime (Optional[int]): The timestamp indicating the starting point from which data was ingested.
+            ctx: Optional context for the request.
+        Returns:
+            Dict[str, Any]: Details of the specified trace.
+        """
 
-    #     try:
-    #         if not id:
-    #             logger.warning("Trace ID must be provided")
-    #             return {"error": "Trace ID must be provided"}
+        try:
+            if not id:
+                logger.warning("Trace ID must be provided")
+                return {"error": "Trace ID must be provided"}
 
-    #         if offset is not None and ingestionTime is None:
-    #             logger.warning("If offset is provided, ingestionTime must also be provided")
-    #             return {"error": "If offset is provided, ingestionTime must also be provided"}
+            if offset is not None and ingestionTime is None:
+                logger.warning("If offset is provided, ingestionTime must also be provided")
+                return {"error": "If offset is provided, ingestionTime must also be provided"}
 
-    #         if retrievalSize is not None and (retrievalSize < 1 or retrievalSize > 10000):
-    #             logger.warning(f"retrievalSize must be between 1 and 10000, got: {retrievalSize}")
-    #             return {"error": "retrievalSize must be between 1 and 10000"}
+            if retrievalSize is not None and (retrievalSize < 1 or retrievalSize > 10000):
+                logger.warning(f"retrievalSize must be between 1 and 10000, got: {retrievalSize}")
+                return {"error": "retrievalSize must be between 1 and 10000"}
 
-    #         logger.debug(f"Fetching trace details for id={id}")
-    #         result = api_client.get_trace_download(
-    #             id=id,
-    #             retrieval_size=retrievalSize,
-    #             offset=offset,
-    #             ingestion_time=ingestionTime
-    #         )
+            logger.debug(f"Fetching trace details for id={id}")
+            result = api_client.get_trace_download(
+                id=id,
+                retrieval_size=retrievalSize,
+                offset=offset,
+                ingestion_time=ingestionTime
+            )
 
-    #         # Convert the result to a dictionary
-    #         if hasattr(result, 'to_dict'):
-    #             result_dict = result.to_dict()
-    #         else:
-    #             # If it's already a dict or another format, use it as is
-    #             result_dict = result
+            # Convert the result to a dictionary
+            if hasattr(result, 'to_dict'):
+                result_dict = result.to_dict()
+            else:
+                # If it's already a dict or another format, use it as is
+                result_dict = result
 
-    #         logger.debug(f"Result from get_trace_details: {result_dict}")
-    #         # Ensure we return a dictionary
-    #         return dict(result_dict) if not isinstance(result_dict, dict) else result_dict
+            logger.debug(f"Result from get_trace_details: {result_dict}")
+            # Ensure we return a dictionary
+            return dict(result_dict) if not isinstance(result_dict, dict) else result_dict
 
-    #     except Exception as e:
-    #         logger.error(f"Error getting trace details: {e}", exc_info=True)
-    #         return {"error": f"Failed to get trace details: {e!s}"}
+        except Exception as e:
+            logger.error(f"Error getting trace details: {e}", exc_info=True)
+            return {"error": f"Failed to get trace details: {e!s}"}
 
 
     # @register_as_tool decorator commented out - not exposed as MCP tool

--- a/src/application/application_analyze.py
+++ b/src/application/application_analyze.py
@@ -166,9 +166,10 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
             ingestionTime (Optional[int]): The timestamp indicating the starting point from which data was ingested.
             ctx: Optional context for the request.
         Returns:
-            Dict[str, Any]: Details of the specified trace.
+            Dict containing filePath, itemCount, fileSizeBytes, canLoadMore,
+            and cursor fields (ingestionTime, offset) if more data available
         """
-
+        output_path = None
         try:
             if not id:
                 logger.warning("Trace ID must be provided")
@@ -181,6 +182,11 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
             if retrievalSize is not None and (retrievalSize < 1 or retrievalSize > 10000):
                 logger.warning(f"retrievalSize must be between 1 and 10000, got: {retrievalSize}")
                 return {"error": "retrievalSize must be between 1 and 10000"}
+
+            # Prepare output path
+            timestamp = int(datetime.now().timestamp())
+            output_dir = os.getenv("INSTANA_API_TEMPORARY_DIR", "/tmp")
+            output_path = f"{output_dir}/instana_trace_details_{id}_{timestamp}.jsonl"
 
             logger.debug(f"Fetching trace details for id={id}")
             result = api_client.get_trace_download(
@@ -198,11 +204,39 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
                 result_dict = result
 
             logger.debug(f"Result from get_trace_details: {result_dict}")
-            # Ensure we return a dictionary
-            return dict(result_dict) if not isinstance(result_dict, dict) else result_dict
+
+            items = result_dict.get("items", [])
+            can_load_more = result_dict.get("canLoadMore", False)
+
+            # Write items to JSONL file
+            with open(output_path, 'w') as f:
+                for item in items:
+                    f.write(json.dumps(item) + '\n')
+
+            file_size = Path(output_path).stat().st_size if Path(output_path).exists() else 0
+
+            # Build response
+            response = {
+                "filePath": output_path,
+                "itemCount": len(items),
+                "fileSizeBytes": file_size,
+                "canLoadMore": can_load_more
+            }
+
+            # Add cursor fields if more data available
+            if items and can_load_more and "cursor" in items[-1]:
+                cursor = items[-1]["cursor"]
+                if "ingestionTime" in cursor:
+                    response["ingestionTime"] = cursor["ingestionTime"]
+                if "offset" in cursor:
+                    response["offset"] = cursor["offset"]
+
+            return response
 
         except Exception as e:
             logger.error(f"Error getting trace details: {e}", exc_info=True)
+            if output_path and Path(output_path).exists():
+                Path(output_path).unlink()
             return {"error": f"Failed to get trace details: {e!s}"}
 
 

--- a/src/application/application_analyze.py
+++ b/src/application/application_analyze.py
@@ -70,8 +70,8 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
         Called by the smart router tool.
 
         Args:
-            operation: Operation to perform (get_all_traces)
-            params: Dictionary containing 'payload'
+            operation: Operation to perform (get_all_traces, get_trace_details)
+            params: Dictionary containing operation-specific parameters
             ctx: MCP context
 
         Returns:
@@ -81,6 +81,14 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
             if operation == "get_all_traces":
                 payload = params.get('payload')
                 return await self.get_all_traces(payload, ctx=ctx)
+            elif operation == "get_trace_details":
+                return await self.get_trace_details(
+                    id=params.get('id'),
+                    retrievalSize=params.get('retrievalSize'),
+                    offset=params.get('offset'),
+                    ingestionTime=params.get('ingestionTime'),
+                    ctx=ctx
+                )
             else:
                 return {"error": f"Operation '{operation}' not supported"}
 

--- a/src/router/application_smart_router_tool.py
+++ b/src/router/application_smart_router_tool.py
@@ -120,7 +120,9 @@ class ApplicationSmartRouterMCPTool(BaseInstanaClient):
             Get metric catalog: operation="get_metric_catalog"
 
         ANALYZE (resource_type="analyze"):
-            operations: get_all_traces
+            operations: get_all_traces, get_trace_details
+
+            get_all_traces:
             params: {payload}
 
             Payload parameters:
@@ -150,6 +152,23 @@ class ApplicationSmartRouterMCPTool(BaseInstanaClient):
             params={"payload": {"timeFrame": {"windowSize": 3600000, "to": 1710658800000}, "pagination": {"retrievalSize": 200, "ingestionTime": 1725519793, "offset": 199}}}
 
             Note: Trace data saved to /tmp/instana_traces_{timestamp}.jsonl. Returns filePath, itemCount, fileSizeBytes, canLoadMore, totalHits, and cursor (ingestionTime, offset) if more data available. Use cursor values in pagination for next page.
+
+            get_trace_details:
+            params: {id, retrievalSize, offset, ingestionTime}
+
+            Parameters:
+            - id (required): Trace ID
+            - retrievalSize (optional): Number of records (1-10000)
+            - offset (optional): Records to skip from ingestionTime
+            - ingestionTime (optional): Starting point timestamp (required if offset provided)
+
+            Example:
+            params={"id": "trace-id-123", "retrievalSize": 100}
+
+            Pagination example:
+            params={"id": "trace-id-123", "retrievalSize": 100, "ingestionTime": 1725519793, "offset": 99}
+
+            Note: Trace details saved to /tmp/instana_trace_details_{id}_{timestamp}.jsonl. Returns filePath, itemCount, fileSizeBytes, canLoadMore, and cursor (ingestionTime, offset) if more data available.
 
         Args:
             resource_type: "metrics", "alert_config", "global_alert_config", "settings", "catalog", or "analyze"
@@ -575,7 +594,7 @@ class ApplicationSmartRouterMCPTool(BaseInstanaClient):
         self, operation: str, params: Dict[str, Any], ctx
     ) -> Dict[str, Any]:
         """Handle Application Analyze operations."""
-        valid_operations = ["get_all_traces"]
+        valid_operations = ["get_all_traces", "get_trace_details"]
 
         if operation not in valid_operations:
             return {

--- a/src/router/application_smart_router_tool.py
+++ b/src/router/application_smart_router_tool.py
@@ -160,7 +160,12 @@ class ApplicationSmartRouterMCPTool(BaseInstanaClient):
             - id (required): Trace ID
             - retrievalSize (optional): Number of records (1-10000)
             - offset (optional): Records to skip from ingestionTime
-            - ingestionTime (optional): Starting point timestamp (required if offset provided)
+            - ingestionTime (optional): Starting point timestamp - can be provided as:
+                - Unix timestamp in seconds (e.g., 1725519793)
+                - Human-readable datetime string (e.g., "10 March 2026, 2:00 PM")
+                - Datetime with timezone (e.g., "10 March 2026, 2:00 PM|IST")
+                - If no timezone specified, UTC is assumed
+                Required if offset provided
 
             Example:
             params={"id": "trace-id-123", "retrievalSize": 100}
@@ -623,6 +628,25 @@ class ApplicationSmartRouterMCPTool(BaseInstanaClient):
 
                     # Update the field with converted timestamp
                     time_frame["to"] = result["timestamp"]
+
+        # Handle datetime string conversion for ingestionTime in get_trace_details
+        if operation == "get_trace_details" and "ingestionTime" in params:
+            ingestion_time = params["ingestionTime"]
+
+            if isinstance(ingestion_time, str):
+                result = self._convert_datetime_field(
+                    ingestion_time,
+                    "ingestionTime",
+                    "analyze",
+                    operation
+                )
+
+                # Check if conversion failed
+                if "error" in result:
+                    return result
+
+                # Update with converted timestamp (milliseconds)
+                params["ingestionTime"] = result["timestamp"]
 
         # Route to the analyze client with params
         result = await self.app_analyze_client.execute_analyze_operation(


### PR DESCRIPTION
https://github.com/instana/mcp-instana/issues/23

## Summary

Enables `get_trace_details` operation for retrieving detailed trace information with file-based output and datetime conversion support.

## Key Changes

- Activated `get_trace_details` method in Application Analyze module
- Added JSONL file output to `/tmp` directory with metadata (file path, item count, file size)
- Implemented datetime string to Unix timestamp conversion for `ingestionTime` parameter
- Added routing logic in `execute_analyze_operation` for the new operation
- Enhanced documentation with usage examples and pagination guidance