### PR TITLE
Bump up mcp-instana-pypi version to 0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 0.9.5
+### 0.9.6
 -  **New Feature:** Introduced a unified smart router to handle all releases-related operations.
 
 ### 0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.9.5
+-  **New Feature:** Introduced a unified smart router to handle all releases-related operations.
+
 ### 0.9.0
 -  **New Feature:**  Introduced a unified smart router to handle all SLO-related operations.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-instana"
-version = "0.9.0"
+version = "0.9.5"
 description = "MCP server for Instana"
 authors = [
     {name = "Elina Priyadarshinee", email = "Elina.priyadarshinee1@ibm.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-instana"
-version = "0.9.5"
+version = "0.9.6"
 description = "MCP server for Instana"
 authors = [
     {name = "Elina Priyadarshinee", email = "Elina.priyadarshinee1@ibm.com"},

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -19,7 +19,7 @@ try:
     __version__ = version("mcp-instana")
 except Exception:
     # Fallback version if package metadata is not available
-    __version__ = "0.9.5"
+    __version__ = "0.9.6"
 
 # Registry to store all tools
 MCP_TOOLS = {}

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -19,7 +19,7 @@ try:
     __version__ = version("mcp-instana")
 except Exception:
     # Fallback version if package metadata is not available
-    __version__ = "0.9.0"
+    __version__ = "0.9.5"
 
 # Registry to store all tools
 MCP_TOOLS = {}

--- a/src/slo/slo_correction_configuration.py
+++ b/src/slo/slo_correction_configuration.py
@@ -9,7 +9,6 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
-from fastmcp.client.client import ClientSamplingHandler
 from instana_client.models.correction_configuration import CorrectionConfiguration
 from instana_client.models.correction_scheduling import CorrectionScheduling
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -826,7 +826,7 @@ class TestVersionImport(unittest.TestCase):
         importlib.reload(src.core.utils)
 
         # Check that the fallback version was used
-        self.assertEqual(src.core.utils.__version__, "0.9.0")
+        self.assertEqual(src.core.utils.__version__, "0.9.5")
 
     def test_version_used_in_headers(self):
         """Test that __version__ is used in User-Agent headers"""

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -826,7 +826,7 @@ class TestVersionImport(unittest.TestCase):
         importlib.reload(src.core.utils)
 
         # Check that the fallback version was used
-        self.assertEqual(src.core.utils.__version__, "0.9.5")
+        self.assertEqual(src.core.utils.__version__, "0.9.6")
 
     def test_version_used_in_headers(self):
         """Test that __version__ is used in User-Agent headers"""

--- a/uv.lock
+++ b/uv.lock
@@ -1142,7 +1142,7 @@ wheels = [
 
 [[package]]
 name = "mcp-instana"
-version = "0.9.0"
+version = "0.9.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1142,7 +1142,7 @@ wheels = [
 
 [[package]]
 name = "mcp-instana"
-version = "0.9.5"
+version = "0.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
# Release v0.9.6: Releases Smart Router Integration

## Changes

* Version bump: `0.9.0` → `0.9.6`
* Updated version references across project files
* Updated `CHANGELOG.md`
* Verified schema files included in distribution
* Published package to PyPI

## Testing

* Updated version assertions
* Verified schema packaging
* Successfully built and uploaded to PyPI

## Installation

```bash
pip install mcp-instana==0.9.6
```

## Notes

* No breaking changes
* Backward compatible

---

**Version:** 0.9.6
**Release Type:** Minor feature release
