### PR TITLE
INSTA-84995: Exclude internal parameters from published tool schemas to resolve Pydantic v2 validation errors.

### DIFF
--- a/src/application/application_alert_config.py
+++ b/src/application/application_alert_config.py
@@ -7,6 +7,7 @@ This module provides application alert configuration tools for Instana monitorin
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.utils import BaseInstanaClient, register_as_tool, with_header_auth
@@ -43,7 +44,7 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
         valid_on: Optional[int] = None,
         created: Optional[int] = None,
         payload: Optional[Union[Dict[str, Any], str]] = None,
-        ctx=None
+        ctx: Optional[Context] = None
     ) -> Dict[str, Any]:
         """
         Execute Application Alert Config CRUD operations.
@@ -97,8 +98,8 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
         self,
         application_id: Optional[str],
         alert_ids: Optional[List[str]],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Find active application alert configs."""
         if not application_id:
@@ -115,8 +116,8 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     async def _find_config_versions(
         self,
         id: Optional[str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Find all versions of an application alert config."""
         if not id:
@@ -133,8 +134,8 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
         self,
         id: Optional[str],
         valid_on: Optional[int],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Find a specific application alert config."""
         return await self.find_application_alert_config(
@@ -148,8 +149,8 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     async def _create_config(
         self,
         payload: Optional[Union[Dict[str, Any], str]],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Create a new application alert config."""
         if not payload:
@@ -166,8 +167,8 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
         self,
         id: Optional[str],
         payload: Optional[Union[Dict[str, Any], str]],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Update an existing application alert config."""
         if not id:
@@ -186,8 +187,8 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     async def _delete_config(
         self,
         id: Optional[str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Delete an application alert config."""
         if not id:
@@ -203,8 +204,8 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     async def _enable_config(
         self,
         id: Optional[str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Enable an application alert config."""
         if not id:
@@ -220,8 +221,8 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     async def _disable_config(
         self,
         id: Optional[str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Disable an application alert config."""
         if not id:
@@ -238,8 +239,8 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
         self,
         id: Optional[str],
         created: Optional[int],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Restore a deleted application alert config."""
         if not id:
@@ -258,8 +259,8 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     async def _update_baseline(
         self,
         id: Optional[str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Update baseline for an application alert config."""
         if not id:
@@ -278,7 +279,7 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     async def find_active_application_alert_configs(self,
                                             application_id: str,
                                             alert_ids: Optional[List[str]] = None,
-                                            ctx=None, api_client=None) -> Dict[str, Any]:
+                                            ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get All Smart Alert Configuration.
 
@@ -359,7 +360,7 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationAlertConfigurationApi)
     async def find_application_alert_config_versions(self,
                                                      id: str,
-                                                     ctx=None, api_client=None) -> Dict[str, Any]:
+                                                     ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get Smart Alert Config Versions. Get all versions of Smart Alert Configuration.
 
@@ -407,7 +408,7 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     async def find_application_alert_config(self,
                                             id: Optional[str] = None,
                                             valid_on: Optional[int] = None,
-                                            ctx=None, api_client=None) -> Dict[str, Any]:
+                                            ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Gets a specific Smart Alert Configuration. This may return a deleted Configuration.
 
@@ -451,7 +452,7 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationAlertConfigurationApi)
     async def delete_application_alert_config(self,
                                               id: str,
-                                              ctx=None, api_client=None) -> Dict[str, Any]:
+                                              ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Deletes a Smart Alert Configuration.
 
@@ -491,7 +492,7 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationAlertConfigurationApi)
     async def enable_application_alert_config(self,
                                               id: str,
-                                              ctx=None, api_client=None) -> Dict[str, Any]:
+                                              ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Enable a Smart Alert Configuration.
 
@@ -535,7 +536,7 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationAlertConfigurationApi)
     async def disable_application_alert_config(self,
                                                id: str,
-                                               ctx=None, api_client=None) -> Dict[str, Any]:
+                                               ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Disable a Smart Alert Configuration.
 
@@ -580,7 +581,7 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     async def restore_application_alert_config(self,
                                                id: str,
                                                created: int,
-                                               ctx=None, api_client=None) -> Dict[str, Any]:
+                                               ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Restore a deleted Smart Alert Configuration.
 
@@ -628,7 +629,7 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationAlertConfigurationApi)
     async def update_application_alert_config_baseline(self,
                                                        id: str,
-                                                       ctx=None, api_client=None) -> Dict[str, Any]:
+                                                       ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Recalculate the historic baseline for a Smart Alert Configuration.
 
@@ -672,7 +673,7 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationAlertConfigurationApi)
     async def create_application_alert_config(self,
                                               payload: Union[Dict[str, Any], str],
-                                              ctx=None, api_client=None) -> Dict[str, Any]:
+                                              ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Creates a new Smart Alert Configuration.
 
@@ -806,7 +807,7 @@ class ApplicationAlertMCPTools(BaseInstanaClient):
     async def update_application_alert_config(self,
                                               id: str,
                                               payload: Union[Dict[str, Any], str],
-                                              ctx=None, api_client=None) -> Dict[str, Any]:
+                                              ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Update an existing Smart Alert Configuration.
 

--- a/src/application/application_analyze.py
+++ b/src/application/application_analyze.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.prompts import mcp
@@ -63,7 +64,7 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
         self,
         operation: str,
         params: Optional[Union[Dict[str, Any], str]] = None,
-        ctx=None,
+        ctx: Optional[Context] = None,
     ) -> Dict[str, Any]:
         """
         Execute Application Analyze operations.
@@ -105,7 +106,7 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
     #     self,
     #     trace_id: str,
     #     call_id: str,
-    #     ctx=None,
+    #     ctx: Optional[Context] = None,
     #     api_client=None
     # ) -> Dict[str, Any]:
     #     """
@@ -160,8 +161,8 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
         retrievalSize: Optional[int] = None,
         offset: Optional[int] = None,
         ingestionTime: Optional[int] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Get details of a specific trace.
@@ -258,7 +259,7 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
         self,
         payload: Optional[Union[Dict[str, Any], str]]=None,
         api_client = None,
-        ctx=None
+        ctx: Optional[Context] = None
     ) -> Dict[str, Any]:
         """
         Get traces from Instana API and save to JSONL file.
@@ -382,8 +383,8 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
     #     self,
     #     payload: Optional[Union[Dict[str, Any], str]]=None,
     #     fill_time_series: Optional[bool] = None,
-    #     api_client=None,
-    #     ctx=None
+    #     api_client: Any = None,
+    #     ctx: Optional[Context] = None
     # ) -> Dict[str, Any]:
     #     """
     #     The API endpoint retrieves metrics for traces that are grouped in the endpoint or service name.
@@ -530,7 +531,7 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
     # #     fillTimeSeries: Optional[str] = None,
     # #     payload: Optional[Union[Dict[str, Any], str]]=None,
     # #     api_client = None,
-    # #     ctx=None
+    # #     ctx: Optional[Context] = None
     # # ) -> Dict[str, Any]:
     # #     """
     # #     Get grouped calls metrics.
@@ -686,7 +687,7 @@ class ApplicationAnalyzeMCPTools(BaseInstanaClient):
     #     self,
     #     correlation_id: str,
     #     api_client = None,
-    #     ctx=None
+    #     ctx: Optional[Context] = None
     # ) -> Dict[str, Any]:
     #     """
     #     Resolve Trace IDs from Monitoring Beacons.

--- a/src/application/application_call_group.py
+++ b/src/application/application_call_group.py
@@ -8,6 +8,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.prompts import mcp
@@ -51,8 +52,8 @@ class ApplicationCallGroupMCPTools(BaseInstanaClient):
         order: Optional[Dict[str, str]] = None,
         pagination: Optional[Dict[str, int]] = None,
         fill_time_series: Optional[bool] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Get grouped calls metrics.

--- a/src/application/application_catalog.py
+++ b/src/application/application_catalog.py
@@ -11,6 +11,7 @@ import traceback
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.utils import (
@@ -46,7 +47,7 @@ class ApplicationCatalogMCPTools(BaseInstanaClient):
                                           use_case: Optional[str] = None,
                                           data_source: Optional[str] = None,
                                           var_from: Optional[int] = None,
-                                          ctx = None, api_client=None) -> Dict[str, Any]:
+                                          ctx = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get application tag catalog data from Instana Server.
         This tool retrieves application tag catalog data for a specific use case and data source.
@@ -109,7 +110,7 @@ class ApplicationCatalogMCPTools(BaseInstanaClient):
 
 
     @with_header_auth(ApplicationCatalogApi)
-    async def get_application_metric_catalog(self, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def get_application_metric_catalog(self, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         This API endpoint retrieves  all available metric definitions for application monitoring.
         This tool allows you to discover what metrics are available for monitoring different components in your application environment.

--- a/src/application/application_global_alert_config.py
+++ b/src/application/application_global_alert_config.py
@@ -7,6 +7,7 @@ This module provides application alert configuration tools for Instana monitorin
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.utils import BaseInstanaClient, register_as_tool, with_header_auth
@@ -43,7 +44,7 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
         valid_on: Optional[int] = None,
         created: Optional[int] = None,
         payload: Optional[Union[Dict[str, Any], str]] = None,
-        ctx=None
+        ctx: Optional[Context] = None
     ) -> Dict[str, Any]:
         """
         Execute Global Application Alert Config CRUD operations.
@@ -95,8 +96,8 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
         self,
         application_id: Optional[str],
         alert_ids: Optional[List[str]],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Find active global application alert configs."""
         if not application_id:
@@ -113,8 +114,8 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     async def _find_config_versions(
         self,
         id: Optional[str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Find all versions of a global application alert config."""
         if not id:
@@ -131,8 +132,8 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
         self,
         id: Optional[str],
         valid_on: Optional[int],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Find a specific global application alert config."""
         return await self.find_global_application_alert_config(
@@ -146,8 +147,8 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     async def _create_config(
         self,
         payload: Optional[Union[Dict[str, Any], str]],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Create a new global application alert config."""
         if not payload:
@@ -164,8 +165,8 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
         self,
         id: Optional[str],
         payload: Optional[Union[Dict[str, Any], str]],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Update an existing global application alert config."""
         if not id:
@@ -184,8 +185,8 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     async def _delete_config(
         self,
         id: Optional[str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Delete a global application alert config."""
         if not id:
@@ -201,8 +202,8 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     async def _enable_config(
         self,
         id: Optional[str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Enable a global application alert config."""
         if not id:
@@ -218,8 +219,8 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     async def _disable_config(
         self,
         id: Optional[str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Disable a global application alert config."""
         if not id:
@@ -236,8 +237,8 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
         self,
         id: Optional[str],
         created: Optional[int],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Restore a deleted global application alert config."""
         if not id:
@@ -259,7 +260,7 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     async def find_active_global_application_alert_configs(self,
                                             application_id: str,
                                             alert_ids: Optional[List[str]] = None,
-                                            ctx=None, api_client=None) -> Dict[str, Any]:
+                                            ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get All Global Smart Alert Configuration.
 
@@ -341,7 +342,7 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     @with_header_auth(GlobalApplicationAlertConfigurationApi)
     async def find_global_application_alert_config_versions(self,
                                                      id: str,
-                                                     ctx=None, api_client=None) -> Dict[str, Any]:
+                                                     ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get Global Smart Alert Config Versions . Get all versions of Global Smart Alert Configuration.
 
@@ -390,7 +391,7 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     async def find_global_application_alert_config(self,
                                             id: Optional[str] = None,
                                             valid_on: Optional[int] = None,
-                                            ctx=None, api_client=None) -> Dict[str, Any]:
+                                            ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Gets a specific Global Smart Alert Configuration. This may return a deleted Configuration.
 
@@ -435,7 +436,7 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     @with_header_auth(GlobalApplicationAlertConfigurationApi)
     async def delete_global_application_alert_config(self,
                                               id: str,
-                                              ctx=None, api_client=None) -> Dict[str, Any]:
+                                              ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Deletes a Global Smart Alert Configuration.
 
@@ -476,7 +477,7 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     @with_header_auth(GlobalApplicationAlertConfigurationApi)
     async def enable_global_application_alert_config(self,
                                               id: str,
-                                              ctx=None, api_client=None) -> Dict[str, Any]:
+                                              ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Enable a Global Smart Alert Configuration.
 
@@ -521,7 +522,7 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     @with_header_auth(GlobalApplicationAlertConfigurationApi)
     async def disable_global_application_alert_config(self,
                                                id: str,
-                                               ctx=None, api_client=None) -> Dict[str, Any]:
+                                               ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Disable a Global Smart Alert Configuration.
 
@@ -567,7 +568,7 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     async def restore_global_application_alert_config(self,
                                                id: str,
                                                created: int,
-                                               ctx=None, api_client=None) -> Dict[str, Any]:
+                                               ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Restore a deleted Global Smart Alert Configuration.
 
@@ -616,7 +617,7 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     @with_header_auth(GlobalApplicationAlertConfigurationApi)
     async def create_global_application_alert_config(self,
                                               payload: Union[Dict[str, Any], str],
-                                              ctx=None, api_client=None) -> Dict[str, Any]:
+                                              ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Creates a new Global Smart Alert Configuration.
 
@@ -759,7 +760,7 @@ class ApplicationGlobalAlertMCPTools(BaseInstanaClient):
     async def update_global_application_alert_config(self,
                                               id: str,
                                               payload: Union[Dict[str, Any], str],
-                                              ctx=None, api_client=None) -> Dict[str, Any]:
+                                              ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Update an existing Global Smart Alert Configuration.
 

--- a/src/application/application_metrics.py
+++ b/src/application/application_metrics.py
@@ -8,6 +8,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.prompts import mcp
@@ -53,7 +54,7 @@ class ApplicationMetricsMCPTools(BaseInstanaClient):
                                               application_id: Optional[str] = None,
                                               service_id: Optional[str] = None,
                                               endpoint_id: Optional[str] = None,
-                                              ctx=None, api_client=None) -> Dict[str, Any]:
+                                              ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get application data metrics using the v2 API.
 
@@ -187,7 +188,7 @@ class ApplicationMetricsMCPTools(BaseInstanaClient):
     #                                   metrics: Optional[List[Dict[str, str]]] = None,
     #                                   time_frame: Optional[Dict[str, int]] = None,
     #                                   fill_time_series: Optional[bool] = True,
-    #                                   ctx=None, api_client=None) -> Dict[str, Any]:
+    #                                   ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
     #     """
     #     Get metrics for a specific application.
 
@@ -268,7 +269,7 @@ class ApplicationMetricsMCPTools(BaseInstanaClient):
     #                                 metrics: Optional[List[Dict[str, str]]] = None,
     #                                 time_frame: Optional[Dict[str, int]] = None,
     #                                 fill_time_series: Optional[bool] = True,
-    #                                 ctx=None, api_client=None) -> Dict[str, Any]:
+    #                                 ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
     #     """
     #     Get metrics for a specific endpoint.
 
@@ -350,7 +351,7 @@ class ApplicationMetricsMCPTools(BaseInstanaClient):
     #                                time_frame: Optional[Dict[str, int]] = None,
     #                                fill_time_series: Optional[bool] = True,
     #                                include_snapshot_ids: Optional[bool] = False,
-    #                                ctx=None, api_client=None) -> Dict[str, Any]:
+    #                                ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
     #     """
     #     Get metrics for a specific service.
 

--- a/src/application/application_resources.py
+++ b/src/application/application_resources.py
@@ -8,6 +8,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.prompts import mcp
@@ -42,8 +43,8 @@ class ApplicationResourcesMCPTools(BaseInstanaClient):
         name_filter: Optional[str] = None,
         window_size: Optional[int] = None,
         to_time: Optional[int] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Internal method to get applications from Application Resources API.
@@ -102,7 +103,7 @@ class ApplicationResourcesMCPTools(BaseInstanaClient):
     #                                     page: Optional[int] = None,
     #                                     page_size: Optional[int] = None,
     #                                     application_boundary_scope: Optional[str] = None,
-    #                                     ctx=None, api_client=None) -> Dict[str, Any]:
+    #                                     ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
     #     """
     #     Get endpoints for all services from Instana. Use this API endpoint if one wants to retrieve a list of Endpoints. A use case could be to view the endpoint id of an Endpoint.
     #     Retrieve a list of application endpoints from Instana. This tool is useful when you need to get information about endpoints across services in your application.
@@ -193,7 +194,7 @@ class ApplicationResourcesMCPTools(BaseInstanaClient):
     #                                    page_size: Optional[int] = None,
     #                                    application_boundary_scope: Optional[str] = None,
     #                                    include_snapshot_ids: Optional[bool] = None,
-    #                                    ctx=None, api_client=None) -> Dict[str, Any]:
+    #                                    ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
     #     """
     #     Retrieve a list of services within application perspectives from Instana. This tool is useful when you need to get information about all services in your monitored applications.
     #     You can filter by service name and other parameters to narrow down results. Use this when you want to see what services exist in your application,
@@ -314,7 +315,7 @@ class ApplicationResourcesMCPTools(BaseInstanaClient):
     #                            page: Optional[int] = None,
     #                            page_size: Optional[int] = None,
     #                            application_boundary_scope: Optional[str] = None,
-    #                            ctx=None, api_client=None) -> List[str]:
+    #                            ctx: Optional[Context] = None, api_client: Any = None) -> List[str]:
     #     """
     #     Retrieve a list of Application Perspectives from Instana. This tool is useful when you need to get information about any one application perspective in Instana.
     #     You can filter by application name and other parameters to narrow down results. Use this tool when you want to see what application perspectives exist, understand their IDs,
@@ -396,7 +397,7 @@ class ApplicationResourcesMCPTools(BaseInstanaClient):
     #                        page: Optional[int] = None,
     #                        page_size: Optional[int] = None,
     #                        include_snapshot_ids: Optional[bool] = None,
-    #                        ctx=None, api_client=None) -> str:
+    #                        ctx: Optional[Context] = None, api_client: Any = None) -> str:
     #     """
     #     Retrieve a list of services from Instana. A use case could be to view the service id, or details,or information of a Service.
     #     This tool is useful when you need to get information about all services across your monitored environment,regardless of which application perspective they belong to.

--- a/src/application/application_settings.py
+++ b/src/application/application_settings.py
@@ -13,6 +13,7 @@ import traceback
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.utils import BaseInstanaClient, register_as_tool, with_header_auth
@@ -81,7 +82,7 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
         id: Optional[str] = None,
         payload: Optional[Union[Dict[str, Any], str]] = None,
         request_body: Optional[List[str]] = None,
-        ctx=None
+        ctx: Optional[Context] = None
     ) -> Dict[str, Any]:
         """
         Execute Application Settings CRUD operations.
@@ -166,8 +167,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     # )
     @with_header_auth(ApplicationSettingsApi)
     async def _get_all_applications_configs(self,
-                                           ctx=None,
-                                           api_client=None) -> List[Dict[str, Any]]:
+                                           ctx: Optional[Context] = None,
+                                           api_client: Any = None) -> List[Dict[str, Any]]:
         """
         All Application Perspectives Configuration
         Get a list of all Application Perspectives with their configuration settings.
@@ -332,8 +333,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _add_application_config(self,
                                       payload: Union[Dict[str, Any], str],
-                                      ctx=None,
-                                      api_client=None) -> Dict[str, Any]:
+                                      ctx: Optional[Context] = None,
+                                      api_client: Any = None) -> Dict[str, Any]:
         """
         Add a new Application Perspective configuration.
 
@@ -397,8 +398,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _get_application_config(self,
                                       id: str,
-                                      ctx=None,
-                                      api_client=None) -> Dict[str, Any]:
+                                      ctx: Optional[Context] = None,
+                                      api_client: Any = None) -> Dict[str, Any]:
         """
         Get an Application Perspective configuration by ID.
 
@@ -430,8 +431,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     async def _update_application_config(self,
                                          id: str,
                                          payload: Union[Dict[str, Any], str],
-                                         ctx=None,
-                                         api_client=None) -> Dict[str, Any]:
+                                         ctx: Optional[Context] = None,
+                                         api_client: Any = None) -> Dict[str, Any]:
         """Update an existing Application Perspective configuration."""
         try:
             if not id or not payload:
@@ -495,8 +496,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _delete_application_config(self,
                                          id: str,
-                                         ctx=None,
-                                         api_client=None) -> Dict[str, Any]:
+                                         ctx: Optional[Context] = None,
+                                         api_client: Any = None) -> Dict[str, Any]:
         """Delete an Application Perspective configuration."""
         try:
             if not id:
@@ -511,8 +512,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     # Endpoint Config Operations
     @with_header_auth(ApplicationSettingsApi)
     async def _get_all_endpoint_configs(self,
-                                        ctx=None,
-                                        api_client=None) -> List[Dict[str, Any]]:
+                                        ctx: Optional[Context] = None,
+                                        api_client: Any = None) -> List[Dict[str, Any]]:
         """Get all Endpoint Perspectives Configuration."""
         try:
             result = api_client.get_endpoint_configs_without_preload_content()
@@ -527,8 +528,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _get_endpoint_config(self,
                                    id: str,
-                                   ctx=None,
-                                   api_client=None) -> Dict[str, Any]:
+                                   ctx: Optional[Context] = None,
+                                   api_client: Any = None) -> Dict[str, Any]:
         """Get an Endpoint configuration by ID."""
         try:
             if not id:
@@ -544,8 +545,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _create_endpoint_config(self,
                                       payload: Union[Dict[str, Any], str],
-                                      ctx=None,
-                                      api_client=None) -> Dict[str, Any]:
+                                      ctx: Optional[Context] = None,
+                                      api_client: Any = None) -> Dict[str, Any]:
         """Create or update endpoint configuration for a service."""
         try:
             if not payload:
@@ -574,8 +575,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     async def _update_endpoint_config(self,
                                       id: str,
                                       payload: Union[Dict[str, Any], str],
-                                      ctx=None,
-                                      api_client=None) -> Dict[str, Any]:
+                                      ctx: Optional[Context] = None,
+                                      api_client: Any = None) -> Dict[str, Any]:
         """Update an endpoint configuration."""
         try:
             if not id or not payload:
@@ -603,8 +604,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _delete_endpoint_config(self,
                                       id: str,
-                                      ctx=None,
-                                      api_client=None) -> Dict[str, Any]:
+                                      ctx: Optional[Context] = None,
+                                      api_client: Any = None) -> Dict[str, Any]:
         """Delete an endpoint configuration."""
         try:
             if not id:
@@ -618,8 +619,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     # Service Config Operations
     @with_header_auth(ApplicationSettingsApi)
     async def _get_all_service_configs(self,
-                                       ctx=None,
-                                       api_client=None) -> List[Dict[str, Any]]:
+                                       ctx: Optional[Context] = None,
+                                       api_client: Any = None) -> List[Dict[str, Any]]:
         """Get all Service configurations."""
         try:
             result = api_client.get_service_configs_without_preload_content()
@@ -634,8 +635,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _get_service_config(self,
                                   id: str,
-                                  ctx=None,
-                                  api_client=None) -> Dict[str, Any]:
+                                  ctx: Optional[Context] = None,
+                                  api_client: Any = None) -> Dict[str, Any]:
         """Get a Service configuration by ID."""
         try:
             if not id:
@@ -651,8 +652,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _add_service_config(self,
                                   payload: Union[Dict[str, Any], str],
-                                  ctx=None,
-                                  api_client=None) -> Dict[str, Any]:
+                                  ctx: Optional[Context] = None,
+                                  api_client: Any = None) -> Dict[str, Any]:
         """Add a new Service configuration."""
         try:
             if not payload:
@@ -681,8 +682,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     async def _update_service_config(self,
                                      id: str,
                                      payload: Union[Dict[str, Any], str],
-                                     ctx=None,
-                                     api_client=None) -> Dict[str, Any]:
+                                     ctx: Optional[Context] = None,
+                                     api_client: Any = None) -> Dict[str, Any]:
         """Update a Service configuration."""
         try:
             if not id or not payload:
@@ -710,8 +711,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _delete_service_config(self,
                                      id: str,
-                                     ctx=None,
-                                     api_client=None) -> Dict[str, Any]:
+                                     ctx: Optional[Context] = None,
+                                     api_client: Any = None) -> Dict[str, Any]:
         """Delete a Service configuration."""
         try:
             if not id:
@@ -725,8 +726,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _order_service_config(self,
                                     request_body: List[str],
-                                    ctx=None,
-                                    api_client=None) -> Dict[str, Any]:
+                                    ctx: Optional[Context] = None,
+                                    api_client: Any = None) -> Dict[str, Any]:
         """Order Service configurations."""
         try:
             if not request_body:
@@ -740,8 +741,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _replace_all_service_configs(self,
                                            payload: Union[Dict[str, Any], str],
-                                           ctx=None,
-                                           api_client=None) -> Dict[str, Any]:
+                                           ctx: Optional[Context] = None,
+                                           api_client: Any = None) -> Dict[str, Any]:
         """Replace all Service configurations."""
         try:
             if not payload:
@@ -768,8 +769,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     # Manual Service Config Operations
     @with_header_auth(ApplicationSettingsApi)
     async def _get_all_manual_service_configs(self,
-                                              ctx=None,
-                                              api_client=None) -> List[Dict[str, Any]]:
+                                              ctx: Optional[Context] = None,
+                                              api_client: Any = None) -> List[Dict[str, Any]]:
         """Get all Manual Service configurations."""
         try:
             result = api_client.get_manual_service_configs_without_preload_content()
@@ -784,8 +785,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _add_manual_service_config(self,
                                          payload: Union[Dict[str, Any], str],
-                                         ctx=None,
-                                         api_client=None) -> Dict[str, Any]:
+                                         ctx: Optional[Context] = None,
+                                         api_client: Any = None) -> Dict[str, Any]:
         """Add a new Manual Service configuration."""
         try:
             if not payload:
@@ -814,8 +815,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     async def _update_manual_service_config(self,
                                             id: str,
                                             payload: Union[Dict[str, Any], str],
-                                            ctx=None,
-                                            api_client=None) -> Dict[str, Any]:
+                                            ctx: Optional[Context] = None,
+                                            api_client: Any = None) -> Dict[str, Any]:
         """Update a Manual Service configuration."""
         try:
             if not id or not payload:
@@ -843,8 +844,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _delete_manual_service_config(self,
                                             id: str,
-                                            ctx=None,
-                                            api_client=None) -> Dict[str, Any]:
+                                            ctx: Optional[Context] = None,
+                                            api_client: Any = None) -> Dict[str, Any]:
         """Delete a Manual Service configuration."""
         try:
             if not id:
@@ -858,8 +859,8 @@ class ApplicationSettingsMCPTools(BaseInstanaClient):
     @with_header_auth(ApplicationSettingsApi)
     async def _replace_all_manual_service_config(self,
                                                  payload: Union[Dict[str, Any], str],
-                                                 ctx=None,
-                                                 api_client=None) -> Dict[str, Any]:
+                                                 ctx: Optional[Context] = None,
+                                                 api_client: Any = None) -> Dict[str, Any]:
         """Replace all Manual Service configurations."""
         try:
             if not payload:

--- a/src/automation/action_catalog.py
+++ b/src/automation/action_catalog.py
@@ -7,6 +7,8 @@ This module provides automation action catalog tools for Instana Automation.
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 # Import the necessary classes from the SDK
 try:
     from instana_client.api.action_catalog_api import (
@@ -34,8 +36,8 @@ class ActionCatalogMCPTools(BaseInstanaClient):
     async def get_action_matches(self,
                             payload: Union[Dict[str, Any], str],
                             target_snapshot_id: Optional[str] = None,
-                            ctx=None,
-                            api_client=None) -> Dict[str, Any]:
+                            ctx: Optional[Context] = None,
+                            api_client: Any = None) -> Dict[str, Any]:
         """
         Get action matches for a given action search space and target snapshot ID.
         Args:
@@ -217,8 +219,8 @@ class ActionCatalogMCPTools(BaseInstanaClient):
 
     @with_header_auth(ActionCatalogApi)
     async def get_actions(self,
-                         ctx=None,
-                         api_client=None) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+                         ctx: Optional[Context] = None,
+                         api_client: Any = None) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
         """
         Get a list of available automation actions from the action catalog.
 
@@ -283,8 +285,8 @@ class ActionCatalogMCPTools(BaseInstanaClient):
     @with_header_auth(ActionCatalogApi)
     async def get_action_details(self,
                                 action_id: str,
-                                ctx=None,
-                                api_client=None) -> Dict[str, Any]:
+                                ctx: Optional[Context] = None,
+                                api_client: Any = None) -> Dict[str, Any]:
         """
         Get detailed information about a specific automation action by ID.
 
@@ -332,8 +334,8 @@ class ActionCatalogMCPTools(BaseInstanaClient):
 
     @with_header_auth(ActionCatalogApi)
     async def get_action_types(self,
-                              ctx=None,
-                              api_client=None) -> Dict[str, Any]:
+                              ctx: Optional[Context] = None,
+                              api_client: Any = None) -> Dict[str, Any]:
         """
         Get a list of available action types in the action catalog.
 
@@ -384,8 +386,8 @@ class ActionCatalogMCPTools(BaseInstanaClient):
 
     @with_header_auth(ActionCatalogApi)
     async def get_action_tags(self,
-                             ctx=None,
-                             api_client=None) -> Dict[str, Any]:
+                             ctx: Optional[Context] = None,
+                             api_client: Any = None) -> Dict[str, Any]:
         """
         Get a list of available action tags from the action catalog.
 
@@ -452,8 +454,8 @@ class ActionCatalogMCPTools(BaseInstanaClient):
                                                        snapshot_id: Optional[str] = None,
                                                        to: Optional[int] = None,
                                                        window_size: Optional[int] = None,
-                                                       ctx=None,
-                                                       api_client=None) -> Dict[str, Any]:
+                                                       ctx: Optional[Context] = None,
+                                                       api_client: Any = None) -> Dict[str, Any]:
         """
         Get automation actions that match based on application ID or snapshot ID within a specified time window.
 

--- a/src/automation/action_history.py
+++ b/src/automation/action_history.py
@@ -7,6 +7,7 @@ This module provides automation action history tools for Instana Automation.
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.utils import BaseInstanaClient, register_as_tool, with_header_auth
@@ -37,8 +38,8 @@ class ActionHistoryMCPTools(BaseInstanaClient):
     @with_header_auth(ActionHistoryApi)
     async def submit_automation_action(self,
                                      payload: Union[Dict[str, Any], str],
-                                     ctx=None,
-                                     api_client=None) -> Dict[str, Any]:
+                                     ctx: Optional[Context] = None,
+                                     api_client: Any = None) -> Dict[str, Any]:
         """
         Submit an automation action for execution on an agent.
         The automation action to execute and the agent on which to execute the action must be specified as actionId and hostId. For more details on the request payload see the request sample.
@@ -171,8 +172,8 @@ class ActionHistoryMCPTools(BaseInstanaClient):
                                         action_instance_id: str,
                                         window_size: Optional[int] = None,
                                         to: Optional[int] = None,
-                                        ctx=None,
-                                        api_client=None) -> Dict[str, Any]:
+                                        ctx: Optional[Context] = None,
+                                        api_client: Any = None) -> Dict[str, Any]:
         """
         Get the details of an automation action run result by ID from action run history.
 
@@ -227,8 +228,8 @@ class ActionHistoryMCPTools(BaseInstanaClient):
                                   action_statuses: Optional[List[str]] = None,
                                   order_by: Optional[str] = None,
                                   order_direction: Optional[str] = None,
-                                  ctx=None,
-                                  api_client=None) -> Dict[str, Any]:
+                                  ctx: Optional[Context] = None,
+                                  api_client: Any = None) -> Dict[str, Any]:
         """
         Get the details of automation action run results from action run history.
 
@@ -290,8 +291,8 @@ class ActionHistoryMCPTools(BaseInstanaClient):
                                    action_instance_id: str,
                                    from_time: int,
                                    to_time: int,
-                                   ctx=None,
-                                   api_client=None) -> Dict[str, Any]:
+                                   ctx: Optional[Context] = None,
+                                   api_client: Any = None) -> Dict[str, Any]:
         """
         Delete an automation action run result from the action run history by ID.
 

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, Union
 import requests
 
 # Import MCP dependencies
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 # Import for getting package version from meta data rather than server.py
@@ -75,16 +76,31 @@ def with_header_auth(api_class, allow_mock=True):
         allow_mock: If True, allows mock clients to be passed directly (for testing). Defaults to True.
 
     Usage:
+        from typing import Any, Optional
+        from fastmcp import Context
+
         @with_header_auth(YourApiClass)
-        async def your_tool_method(self, param1, param2, ctx=None, api_client=None):
+        async def your_tool_method(self, param1, param2, ctx: Optional[Context] = None, api_client: Any = None):
             # The decorator automatically injects 'api_client' into the method
             result = api_client.your_api_method(param1, param2)
             return self._convert_to_dict(result)
 
-    Note: Always include 'api_client=None' in your method signature to receive the
-    injected API client from the decorator.
+    Note: Always type-annotate both 'ctx' (with Optional[Context]) and 'api_client' (with Any)
+    to exclude them from the published schema. These are internal parameters injected by the decorator.
     """
     def decorator(func: Callable) -> Callable:
+        # Get the original function signature
+        import inspect
+        sig = inspect.signature(func)
+
+        # Create a new signature excluding api_client parameter
+        # Keep parameters as Parameter objects, not just names
+        new_params = [
+            param for name, param in sig.parameters.items()
+            if name not in ('api_client',)  # Don't exclude 'self' here, it's needed
+        ]
+
+        # Create wrapper with modified signature for schema generation
         @wraps(func)
         async def wrapper(self, *args, **kwargs):
             try:
@@ -160,10 +176,12 @@ def with_header_auth(api_class, allow_mock=True):
 
                 # Check if the class has the expected API attribute
                 api_attr_name = None
+                # Safely get the API class name
+                api_class_name = getattr(api_class, '__name__', str(api_class))
                 for attr_name in dir(self):
                     if attr_name.endswith('_api'):
                         attr = getattr(self, attr_name)
-                        if hasattr(attr, '__class__') and attr.__class__.__name__ == api_class.__name__:
+                        if hasattr(attr, '__class__') and attr.__class__.__name__ == api_class_name:
                             api_attr_name = attr_name
                             print(f"🔐 Found existing API client: {attr_name}", file=sys.stderr)
                             break
@@ -204,6 +222,9 @@ def with_header_auth(api_class, allow_mock=True):
                 else:
                     error_msg = f"Authentication error: {e!s}"
                 return {"error": error_msg}
+
+        # Apply the modified signature to the wrapper (excluding api_client from schema)
+        wrapper.__signature__ = sig.replace(parameters=new_params)
 
         return wrapper
     return decorator

--- a/src/custom_dashboard/custom_dashboard_tools.py
+++ b/src/custom_dashboard/custom_dashboard_tools.py
@@ -9,6 +9,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.utils import (
@@ -42,7 +43,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
         self,
         operation: str,
         params: Optional[Dict[str, Any]] = None,
-        ctx=None
+        ctx: Optional[Context] = None
     ) -> Dict[str, Any]:
         """
         Execute Custom Dashboard CRUD operations.
@@ -124,8 +125,8 @@ class CustomDashboardMCPTools(BaseInstanaClient):
                                    page_size: Optional[int] = None,
                                    page: Optional[int] = None,
                                    with_total_hits: Optional[bool] = None,
-                                   ctx=None,
-                                   api_client=None) -> Dict[str, Any]:
+                                   ctx: Optional[Context] = None,
+                                   api_client: Any = None) -> Dict[str, Any]:
         """
         Get all custom dashboards from Instana server.
         Uses api/custom-dashboard endpoint.
@@ -188,7 +189,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     @with_header_auth(CustomDashboardsApi)
     async def get_custom_dashboard(self,
                                   dashboard_id: str,
-                                  ctx=None, api_client=None) -> Dict[str, Any]:
+                                  ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get a specific custom dashboard by ID from Instana server.
         Uses api/custom-dashboard/{id} endpoint.
@@ -226,7 +227,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     @with_header_auth(CustomDashboardsApi)
     async def add_custom_dashboard(self,
                                   custom_dashboard: Dict[str, Any],
-                                  ctx=None, api_client=None) -> Dict[str, Any]:
+                                  ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Add a new custom dashboard to Instana server.
         Uses api/custom-dashboard POST endpoint.
@@ -287,7 +288,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     async def update_custom_dashboard(self,
                                      dashboard_id: str,
                                      custom_dashboard: Dict[str, Any],
-                                     ctx=None, api_client=None) -> Dict[str, Any]:
+                                     ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Update an existing custom dashboard in Instana server.
         Uses api/custom-dashboard/{id} PUT endpoint.
@@ -350,7 +351,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     @with_header_auth(CustomDashboardsApi)
     async def delete_custom_dashboard(self,
                                      dashboard_id: str,
-                                     ctx=None, api_client=None) -> Dict[str, Any]:
+                                     ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Delete a custom dashboard from Instana server.
         Uses api/custom-dashboard/{id} DELETE endpoint.
@@ -395,7 +396,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     @with_header_auth(CustomDashboardsApi)
     async def get_shareable_users(self,
                                  dashboard_id: Optional[str] = None,
-                                 ctx=None, api_client=None) -> Dict[str, Any]:
+                                 ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get all users that have access to shareable custom dashboards.
         Note: This returns ALL users globally, not for a specific dashboard.
@@ -439,7 +440,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     @with_header_auth(CustomDashboardsApi)
     async def get_shareable_api_tokens(self,
                                       dashboard_id: Optional[str] = None,
-                                      ctx=None, api_client=None) -> Dict[str, Any]:
+                                      ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get all API tokens that have access to shareable custom dashboards.
         Note: This returns ALL API tokens globally, not for a specific dashboard.

--- a/src/event/events_tools.py
+++ b/src/event/events_tools.py
@@ -11,6 +11,8 @@ import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 try:
     from instana_client.api.events_api import (
         EventsApi,
@@ -486,7 +488,7 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
         return summary
 
     @with_header_auth(EventsApi)
-    async def get_event(self, event_id: str, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def get_event(self, event_id: str, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get a specific event by ID.
 
@@ -580,7 +582,7 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
                                          to_time: Optional[int] = None,
                                          time_range: Optional[str] = None,
                                          max_events: Optional[int] = 50,
-                                         ctx=None, api_client=None) -> Dict[str, Any]:
+                                         ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get Kubernetes info events based on the provided parameters and return a detailed analysis.
 
@@ -750,7 +752,7 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
                                           size: Optional[int] = 100,
                                           max_events: Optional[int] = 50,
                                           time_range: Optional[str] = None,
-                                          ctx=None, api_client=None) -> Dict[str, Any]:
+                                          ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get agent monitoring events from Instana and return a detailed analysis.
 
@@ -894,7 +896,7 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
                              max_events: Optional[int] = 50,
                              size: Optional[int] = 100,
                              time_range: Optional[str] = None,
-                             ctx=None, api_client=None) -> Dict[str, Any]:
+                             ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get issue events from Instana based on the provided parameters.
 
@@ -999,7 +1001,7 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
                              max_events: Optional[int] = 50,
                              size: Optional[int] = 100,
                              time_range: Optional[str] = None,
-                             ctx=None, api_client=None) -> Dict[str, Any]:
+                             ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get incident events from Instana based on the provided parameters.
 
@@ -1095,7 +1097,7 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
                              max_events: Optional[int] = 50,
                              size: Optional[int] = 100,
                              time_range: Optional[str] = None,
-                             ctx=None, api_client=None) -> Dict[str, Any]:
+                             ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get change events from Instana based on the provided parameters.
 
@@ -1185,7 +1187,7 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
     async def get_events_by_ids(
         self,
         event_ids: Union[List[str], str],
-        ctx=None, api_client=None) -> Dict[str, Any]:
+        ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get events by their IDs.
         This tool retrieves multiple events at once using their unique IDs.

--- a/src/infrastructure/infrastructure_analyze.py
+++ b/src/infrastructure/infrastructure_analyze.py
@@ -17,6 +17,8 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from fastmcp import Context
+
 try:
     from instana_client.api.infrastructure_analyze_api import InfrastructureAnalyzeApi
 except ImportError as e:
@@ -94,8 +96,8 @@ class InfrastructureAnalyze(BaseInstanaClient):
         intent: Optional[str] = None,
         entity: Optional[str] = None,
         selections: Optional[Dict[str, Any]] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> List[Any]:
         """
         Two-pass infrastructure analysis using machine-facing elicitation.

--- a/src/infrastructure/infrastructure_analyze_old.py
+++ b/src/infrastructure/infrastructure_analyze_old.py
@@ -8,6 +8,8 @@ import logging
 import sys
 from typing import Any, Dict, Optional, Union
 
+from fastmcp import Context
+
 # Import the necessary classes from the SDK
 try:
     from instana_client.api.infrastructure_analyze_api import (
@@ -56,7 +58,7 @@ class InfrastructureAnalyzeMCPTools(BaseInstanaClient):
     @with_header_auth(InfrastructureAnalyzeApi)
     async def get_available_metrics(self,
                                     payload: Optional[Union[Dict[str, Any], str]] = None,
-                                    ctx=None, api_client=None) -> Dict[str, Any]:
+                                    ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get available metrics for infrastructure monitoring.
 
@@ -191,7 +193,7 @@ class InfrastructureAnalyzeMCPTools(BaseInstanaClient):
     @with_header_auth(InfrastructureAnalyzeApi)
     async def get_entities(self,
                            payload: Optional[Union[Dict[str, Any], str]] = None,
-                           ctx=None, api_client=None) -> Dict[str, Any]:
+                           ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get infrastructure entities for a given entity type along with requested metrics.
 
@@ -305,7 +307,7 @@ class InfrastructureAnalyzeMCPTools(BaseInstanaClient):
     @with_header_auth(InfrastructureAnalyzeApi)
     async def get_aggregated_entity_groups(self,
                                            payload: Optional[Union[Dict[str, Any], str]] = None,
-                                           ctx=None, api_client=None) -> Dict[str, Any]:
+                                           ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get grouped infrastructure entities with aggregated metrics.
 
@@ -505,7 +507,7 @@ class InfrastructureAnalyzeMCPTools(BaseInstanaClient):
     @with_header_auth(InfrastructureAnalyzeApi)
     async def get_available_plugins(self,
                                     payload: Optional[Union[Dict[str, Any], str]] = None,
-                                    ctx=None, api_client=None) -> Dict[str, Any]:
+                                    ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get available plugins for infrastructure monitoring.
 

--- a/src/infrastructure/infrastructure_catalog.py
+++ b/src/infrastructure/infrastructure_catalog.py
@@ -7,6 +7,8 @@ This module provides infrastructure catalog-specific MCP tools for Instana monit
 import logging
 from typing import Any, Dict, List, Optional
 
+from fastmcp import Context
+
 # Import the necessary classes from the SDK
 try:
     from instana_client.api.infrastructure_catalog_api import (
@@ -38,7 +40,7 @@ class InfrastructureCatalogMCPTools(BaseInstanaClient):
     @with_header_auth(InfrastructureCatalogApi)
     async def get_available_payload_keys_by_plugin_id(self,
                                                       plugin_id: str,
-                                                      ctx=None, api_client=None) -> Dict[str, Any]:
+                                                      ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get available payload keys for a specific plugin in Instana. This tool retrieves the list of payload keys that can be used to access detailed monitoring data
         for a particular plugin type. Use this when you need to understand what data is available for a specific entity type, want to explore the monitoring capabilities
@@ -144,7 +146,7 @@ class InfrastructureCatalogMCPTools(BaseInstanaClient):
     async def get_infrastructure_catalog_metrics(self,
                                                  plugin: str,
                                                  filter: Optional[str] = None,
-                                                 ctx=None, api_client=None) -> List[str]:
+                                                 ctx: Optional[Context] = None, api_client: Any = None) -> List[str]:
         """
         Get metric catalog for a specific plugin in Instana. This tool retrieves all available metric definitions for a requested plugin type.
         Use this when you need to understand what metrics are available for a specific technology, want to explore the monitoring capabilities for a plugin,
@@ -244,7 +246,7 @@ class InfrastructureCatalogMCPTools(BaseInstanaClient):
 
     # @register_as_tool(...)  # Disabled for future reference
     @with_header_auth(InfrastructureCatalogApi)
-    async def get_infrastructure_catalog_plugins(self, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def get_infrastructure_catalog_plugins(self, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get plugin catalog from Instana. This tool retrieves all available plugin IDs for your monitored system, showing what types of entities Instana is monitoring in your environment.
         Use this when you need to understand what technologies are being monitored, want to explore the monitoring capabilities of your Instana installation,
@@ -314,7 +316,7 @@ class InfrastructureCatalogMCPTools(BaseInstanaClient):
 
     # @register_as_tool(...)  # Disabled for future reference
     @with_header_auth(InfrastructureCatalogApi)
-    async def get_infrastructure_catalog_plugins_with_custom_metrics(self, ctx=None, api_client=None) -> Dict[str, Any] | List[Dict[str, Any]]:
+    async def get_infrastructure_catalog_plugins_with_custom_metrics(self, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any] | List[Dict[str, Any]]:
         """
         Get all plugins with custom metrics catalog from Instana. This tool retrieves information about which entity types (plugins) in your environment have custom metrics configured.
         Use this when you need to identify which technologies have custom monitoring metrics defined, want to explore custom monitoring capabilities,
@@ -354,7 +356,7 @@ class InfrastructureCatalogMCPTools(BaseInstanaClient):
 
     # @register_as_tool(...)  # Disabled for future reference
     @with_header_auth(InfrastructureCatalogApi)
-    async def get_tag_catalog(self, plugin: str, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def get_tag_catalog(self, plugin: str, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get available tags for a particular plugin. This tool retrieves the tag catalog filtered by plugin.
 
@@ -451,7 +453,7 @@ class InfrastructureCatalogMCPTools(BaseInstanaClient):
 
     # @register_as_tool(...)  # Disabled for future reference
     @with_header_auth(InfrastructureCatalogApi)
-    async def get_tag_catalog_all(self, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def get_tag_catalog_all(self, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get all available tags. This tool retrieves the complete list of all tags available in your Instana-monitored environment. It returns every tag across all plugins, services, and technologies, allowing users to explore the full tagging taxonomy.
 
@@ -570,7 +572,7 @@ class InfrastructureCatalogMCPTools(BaseInstanaClient):
 
     # @register_as_tool(...)  # Disabled for future reference
     @with_header_auth(InfrastructureCatalogApi)
-    async def get_infrastructure_catalog_search_fields(self, ctx=None, api_client=None) -> List[str] | Dict[str, Any]:
+    async def get_infrastructure_catalog_search_fields(self, ctx: Optional[Context] = None, api_client: Any = None) -> List[str] | Dict[str, Any]:
         """
         Get search field catalog from Instana. This tool retrieves all available search keywords and fields that can be used in dynamic focus queries for infrastructure monitoring.
         Use this when you need to understand what search criteria are available, want to build complex queries to filter entities, or need to find the correct search syntax for specific entity properties.

--- a/src/infrastructure/infrastructure_metrics.py
+++ b/src/infrastructure/infrastructure_metrics.py
@@ -9,6 +9,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 from pydantic import StrictBool
 
@@ -52,7 +53,7 @@ class InfrastructureMetricsMCPTools(BaseInstanaClient):
                                          rollup: Optional[int] = None,
                                          query: Optional[str] = None,
                                          plugin: Optional[str]=None,
-                                         ctx=None, api_client=None) -> Dict[str, Any]:
+                                         ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get infrastructure metrics from Instana server.
         This tool retrieves infrastructure metrics for specific components in your environment.

--- a/src/infrastructure/infrastructure_resources.py
+++ b/src/infrastructure/infrastructure_resources.py
@@ -9,6 +9,8 @@ import sys
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 # Import the necessary classes from the SDK
 try:
     from instana_client.api.infrastructure_resources_api import (  #type: ignore
@@ -41,7 +43,7 @@ class InfrastructureResourcesMCPTools(BaseInstanaClient):
 
     # @register_as_tool(...)  # Disabled for future reference
     @with_header_auth(InfrastructureResourcesApi)
-    async def get_monitoring_state(self, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def get_monitoring_state(self, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get the current monitoring state of the Instana system. This tool retrieves details about the number of monitored hosts and serverless entities in your environment.
         Use this when you need an overview of your monitoring coverage, want to check how many hosts are being monitored, or need to verify the scale of your Instana deployment.
@@ -72,7 +74,7 @@ class InfrastructureResourcesMCPTools(BaseInstanaClient):
                                  payload_key: str,
                                  to_time: Optional[int] = None,
                                  window_size: Optional[int] = None,
-                                 ctx=None, api_client=None) -> Dict[str, Any]:
+                                 ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get detailed payload data for a specific snapshot in Instana. This tool retrieves raw monitoring data for a particular entity snapshot using its ID and a specific payload key.
         Use this when you need to access detailed, low-level monitoring information that isn't available through other APIs.
@@ -112,7 +114,7 @@ class InfrastructureResourcesMCPTools(BaseInstanaClient):
                            snapshot_id: str,
                            to_time: Optional[int] = None,
                            window_size: Optional[int] = None,
-                           ctx=None, api_client=None) -> Dict[str, Any]:
+                           ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get detailed information about a specific snapshot in Instana using its ID.
 
@@ -224,7 +226,7 @@ class InfrastructureResourcesMCPTools(BaseInstanaClient):
                             plugin: Optional[str] = None,
                             offline: Optional[bool] = False,
                             detailed: Optional[bool] = False,
-                            ctx=None, api_client=None) -> Dict[str, Any]:
+                            ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Search and discover snapshots based on search criteria.
 
@@ -376,7 +378,7 @@ class InfrastructureResourcesMCPTools(BaseInstanaClient):
                              to_time: Optional[int] = None,
                              window_size: Optional[int] = None,
                              detailed: Optional[bool] = False,
-                             ctx=None, api_client=None) -> Dict[str, Any]:
+                             ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get details for multiple snapshots by their IDs using SDK.
 
@@ -549,7 +551,7 @@ class InfrastructureResourcesMCPTools(BaseInstanaClient):
 
     # @register_as_tool(...)  # Disabled for future reference
     @with_header_auth(InfrastructureResourcesApi)
-    async def software_versions(self, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def software_versions(self, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get information about installed software versions across the monitored infrastructure.
         Retrieve information about the software that are sensed by the agent remotely, natively, or both. This includes runtime and package manager information.

--- a/src/infrastructure/infrastructure_topology.py
+++ b/src/infrastructure/infrastructure_topology.py
@@ -8,6 +8,8 @@ import logging
 import sys
 from typing import Any, Dict, Optional
 
+from fastmcp import Context
+
 # Import the necessary classes from the SDK
 try:
     from instana_client.api.infrastructure_topology_api import (
@@ -57,8 +59,8 @@ class InfrastructureTopologyMCPTools(BaseInstanaClient):
                                 snapshot_id: str,
                                 to_time: Optional[int] = None,
                                 window_size: Optional[int] = None,
-                                ctx=None,
-                                api_client=None) -> Dict[str, Any]:
+                                ctx: Optional[Context] = None,
+                                api_client: Any = None) -> Dict[str, Any]:
         """
         Get hosts related to a specific snapshot.
 
@@ -116,8 +118,8 @@ class InfrastructureTopologyMCPTools(BaseInstanaClient):
     @with_header_auth(InfrastructureTopologyApi)
     async def get_topology(self,
                            include_data: Optional[bool] = False,
-                           ctx=None,
-                           api_client=None) -> Dict[str, Any]:
+                           ctx: Optional[Context] = None,
+                           api_client: Any = None) -> Dict[str, Any]:
         """
         Get the infrastructure topology information.
 

--- a/src/log/log_alert_configuration.py
+++ b/src/log/log_alert_configuration.py
@@ -9,6 +9,8 @@ import sys
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from fastmcp import Context
+
 # Configure logger for this module
 logger = logging.getLogger(__name__)
 
@@ -58,7 +60,7 @@ class LogAlertConfigurationMCPTools(BaseInstanaClient):
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False)
     )
     @with_header_auth(LogAlertConfigurationApi)
-    async def create_log_alert_config(self, config: Dict[str, Any], ctx=None, api_client=None) -> Dict[str, Any]:
+    async def create_log_alert_config(self, config: Dict[str, Any], ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Create a new log alert configuration.
 
@@ -103,7 +105,7 @@ class LogAlertConfigurationMCPTools(BaseInstanaClient):
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True)
     )
     @with_header_auth(LogAlertConfigurationApi)
-    async def delete_log_alert_config(self, id: str, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def delete_log_alert_config(self, id: str, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Delete a log alert configuration.
 
@@ -133,7 +135,7 @@ class LogAlertConfigurationMCPTools(BaseInstanaClient):
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False)
     )
     @with_header_auth(LogAlertConfigurationApi)
-    async def disable_log_alert_config(self, id: str, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def disable_log_alert_config(self, id: str, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Disable a log alert configuration.
 
@@ -163,7 +165,7 @@ class LogAlertConfigurationMCPTools(BaseInstanaClient):
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False)
     )
     @with_header_auth(LogAlertConfigurationApi)
-    async def enable_log_alert_config(self, id: str, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def enable_log_alert_config(self, id: str, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Enable a log alert configuration.
 
@@ -193,7 +195,7 @@ class LogAlertConfigurationMCPTools(BaseInstanaClient):
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False)
     )
     @with_header_auth(LogAlertConfigurationApi)
-    async def find_active_log_alert_configs(self, alert_ids: Optional[List[str]] = None, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def find_active_log_alert_configs(self, alert_ids: Optional[List[str]] = None, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get all active log alert configurations.
 
@@ -235,7 +237,7 @@ class LogAlertConfigurationMCPTools(BaseInstanaClient):
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False)
     )
     @with_header_auth(LogAlertConfigurationApi)
-    async def find_log_alert_config(self, id: str, valid_on: Optional[int] = None, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def find_log_alert_config(self, id: str, valid_on: Optional[int] = None, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get a specific log alert configuration by ID.
 
@@ -278,7 +280,7 @@ class LogAlertConfigurationMCPTools(BaseInstanaClient):
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False)
     )
     @with_header_auth(LogAlertConfigurationApi)
-    async def find_log_alert_config_versions(self, id: str, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def find_log_alert_config_versions(self, id: str, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get all versions of a log alert configuration.
 
@@ -320,7 +322,7 @@ class LogAlertConfigurationMCPTools(BaseInstanaClient):
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False)
     )
     @with_header_auth(LogAlertConfigurationApi)
-    async def restore_log_alert_config(self, id: str, created: int, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def restore_log_alert_config(self, id: str, created: int, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Restore a log alert configuration to a previous version.
 
@@ -354,7 +356,7 @@ class LogAlertConfigurationMCPTools(BaseInstanaClient):
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False)
     )
     @with_header_auth(LogAlertConfigurationApi)
-    async def update_log_alert_config(self, id: str, config: Dict[str, Any], ctx=None, api_client=None) -> Dict[str, Any]:
+    async def update_log_alert_config(self, id: str, config: Dict[str, Any], ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Update a log alert configuration.
 

--- a/src/releases/releases_tools.py
+++ b/src/releases/releases_tools.py
@@ -8,6 +8,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
+from fastmcp import Context
 from instana_client.api.releases_api import ReleasesApi
 from instana_client.models.release import Release
 
@@ -47,8 +48,8 @@ class ReleasesMCPTools(BaseInstanaClient):
         name_filter: Optional[str] = None,
         page_number: Optional[int] = None,
         page_size: Optional[int] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Get all releases within a time range with pagination and filtering support.
@@ -166,8 +167,8 @@ class ReleasesMCPTools(BaseInstanaClient):
     async def get_release(
         self,
         release_id: str,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Get a specific release by ID.
@@ -213,8 +214,8 @@ class ReleasesMCPTools(BaseInstanaClient):
         start: int,
         applications: Optional[List[Dict[str, str]]] = None,
         services: Optional[List[Dict[str, Any]]] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Create a new release.
@@ -284,8 +285,8 @@ class ReleasesMCPTools(BaseInstanaClient):
         start: int,
         applications: Optional[List[Dict[str, str]]] = None,
         services: Optional[List[Dict[str, Any]]] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Update an existing release.
@@ -351,8 +352,8 @@ class ReleasesMCPTools(BaseInstanaClient):
     async def delete_release(
         self,
         release_id: str,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Delete a release.

--- a/src/router/application_smart_router_tool.py
+++ b/src/router/application_smart_router_tool.py
@@ -8,6 +8,7 @@ application-specific tools for Instana monitoring.
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.timestamp_utils import convert_to_timestamp
@@ -56,7 +57,7 @@ class ApplicationSmartRouterMCPTool(BaseInstanaClient):
         resource_type: str,
         operation: str,
         params: Optional[Dict[str, Any]] = None,
-        ctx=None
+        ctx: Optional[Context] = None
     ) -> Dict[str, Any]:
         """
         Unified Instana application resource manager for metrics, alerts, configurations, and catalog.

--- a/src/router/automation_smart_router_tool.py
+++ b/src/router/automation_smart_router_tool.py
@@ -7,6 +7,7 @@ Automation-specific tools for Instana monitoring.
 import logging
 from typing import Any, Dict, Optional, Union
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.utils import BaseInstanaClient, register_as_tool
@@ -101,7 +102,7 @@ class AutomationSmartRouterMCPTool(BaseInstanaClient):
         resource_type: str,
         operation: str,
         params: Optional[Dict[str, Any]] = None,
-        ctx=None
+        ctx: Optional[Context] = None
     ) -> Dict[str, Any]:
         """
         Unified Instana automation action manager for catalog and execution history.

--- a/src/router/custom_dashboard_smart_router_tool.py
+++ b/src/router/custom_dashboard_smart_router_tool.py
@@ -8,6 +8,7 @@ custom dashboard-specific tools for Instana monitoring.
 import logging
 from typing import Any, Dict, Optional
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.utils import BaseInstanaClient, register_as_tool
@@ -40,7 +41,7 @@ class CustomDashboardSmartRouterMCPTool(BaseInstanaClient):
         self,
         operation: str,
         params: Optional[Dict[str, Any]] = None,
-        ctx=None
+        ctx: Optional[Context] = None
     ) -> Dict[str, Any]:
         """
         Unified Instana custom dashboard manager for CRUD operations.

--- a/src/router/events_smart_router_tool.py
+++ b/src/router/events_smart_router_tool.py
@@ -8,6 +8,7 @@ to the appropriate specialized tools.
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.utils import BaseInstanaClient, register_as_tool
@@ -83,7 +84,7 @@ class EventsSmartRouterMCPTool(BaseInstanaClient):
         self,
         operation: str,
         params: Optional[Dict[str, Any]] = None,
-        ctx=None
+        ctx: Optional[Context] = None
     ) -> Dict[str, Any]:
         """
         Unified Instana events resource manager for events monitoring operations.

--- a/src/router/releases_smart_router_tool.py
+++ b/src/router/releases_smart_router_tool.py
@@ -8,6 +8,7 @@ to the appropriate specialized tools.
 import logging
 from typing import Any, Dict, List, Optional
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.timestamp_utils import convert_to_timestamp
@@ -57,7 +58,7 @@ class ReleasesSmartRouterMCPTool(BaseInstanaClient):
         self,
         operation: str,
         params: Optional[Dict[str, Any]] = None,
-        ctx=None
+        ctx: Optional[Context] = None
     ) -> Dict[str, Any]:
         """
         Unified releases manager for tracking deployments and analyzing release impact.

--- a/src/router/slo_smart_router_tool.py
+++ b/src/router/slo_smart_router_tool.py
@@ -8,6 +8,7 @@ queries to the appropriate specialized tools.
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.timestamp_utils import convert_to_timestamp
@@ -145,7 +146,7 @@ class SLOSmartRouterMCPTool(BaseInstanaClient):
         resource_type: str,
         operation: str,
         params: Optional[Dict[str, Any]] = None,
-        ctx=None
+        ctx: Optional[Context] = None
     ) -> Dict[str, Any]:
         """
         Unified SLO manager for configurations, reports, alerts, and corrections.

--- a/src/router/website_smart_router.py
+++ b/src/router/website_smart_router.py
@@ -8,6 +8,7 @@ to the appropriate specialized tools.
 import logging
 from typing import Any, Dict, List, Optional
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.utils import BaseInstanaClient, register_as_tool
@@ -67,7 +68,7 @@ class WebsiteSmartRouterMCPTool(BaseInstanaClient):
         resource_type: str,
         operation: str,
         params: Optional[Dict[str, Any]] = None,
-        ctx=None
+        ctx: Optional[Context] = None
     ) -> Dict[str, Any]:
         """
         Unified Instana website resource manager for beacon monitoring, catalog, and configuration operations.

--- a/src/settings/custom_dashboard_tools.py
+++ b/src/settings/custom_dashboard_tools.py
@@ -8,6 +8,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
+from fastmcp import Context
 from mcp.types import ToolAnnotations
 
 from src.core.utils import (
@@ -42,7 +43,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     )
     @with_header_auth(CustomDashboardsApi)
     async def get_custom_dashboards(self,
-                                   ctx=None, api_client=None) -> Dict[str, Any]:
+                                   ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get all custom dashboards from Instana server.
         This tool retrieves a list of all custom dashboards configured in your Instana environment.
@@ -101,7 +102,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     @with_header_auth(CustomDashboardsApi)
     async def get_custom_dashboard(self,
                                   dashboard_id: str,
-                                  ctx=None, api_client=None) -> Dict[str, Any]:
+                                  ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get a specific custom dashboard by ID from Instana server.
         This tool retrieves detailed information about a specific custom dashboard including
@@ -152,7 +153,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     @with_header_auth(CustomDashboardsApi)
     async def add_custom_dashboard(self,
                                   custom_dashboard: Dict[str, Any],
-                                  ctx=None, api_client=None) -> Dict[str, Any]:
+                                  ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Add a new custom dashboard to Instana server.
         This tool creates a new custom dashboard with the specified configuration,
@@ -211,7 +212,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     async def update_custom_dashboard(self,
                                      dashboard_id: str,
                                      custom_dashboard: Dict[str, Any],
-                                     ctx=None, api_client=None) -> Dict[str, Any]:
+                                     ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Update an existing custom dashboard in Instana server.
         This tool updates a custom dashboard with new configuration, widgets, or access rules.
@@ -272,7 +273,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     @with_header_auth(CustomDashboardsApi)
     async def delete_custom_dashboard(self,
                                      dashboard_id: str,
-                                     ctx=None, api_client=None) -> Dict[str, Any]:
+                                     ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Delete a custom dashboard from Instana server.
         This tool removes a custom dashboard from your Instana environment.
@@ -322,7 +323,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     @with_header_auth(CustomDashboardsApi)
     async def get_shareable_users(self,
                                  dashboard_id: str,
-                                 ctx=None, api_client=None) -> Dict[str, Any]:
+                                 ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get shareable users for a custom dashboard from Instana server.
         This tool retrieves the list of users who can be granted access to a specific custom dashboard.
@@ -384,7 +385,7 @@ class CustomDashboardMCPTools(BaseInstanaClient):
     @with_header_auth(CustomDashboardsApi)
     async def get_shareable_api_tokens(self,
                                       dashboard_id: str,
-                                      ctx=None, api_client=None) -> Dict[str, Any]:
+                                      ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get shareable API tokens for a custom dashboard from Instana server.
         This tool retrieves the list of API tokens that can be used to access a specific custom dashboard.

--- a/src/slo/slo_alert_config.py
+++ b/src/slo/slo_alert_config.py
@@ -8,6 +8,8 @@ import json
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 try:
     from instana_client.api.service_levels_alert_configuration_api import (
         ServiceLevelsAlertConfigurationApi,
@@ -420,8 +422,8 @@ class SLOAlertConfigMCPTools(BaseInstanaClient):
     async def find_active_alert_configs(self,
         slo_id: Optional[str] = None,
         alert_ids: Optional[List[str]] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Find active SLO alert configurations."""
         try:
@@ -453,8 +455,8 @@ class SLOAlertConfigMCPTools(BaseInstanaClient):
     async def find_alert_config(self,
         id: str,
         valid_on: Optional[int] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Find specific SLO alert configuration by ID."""
         try:
@@ -488,8 +490,8 @@ class SLOAlertConfigMCPTools(BaseInstanaClient):
     @with_header_auth(ServiceLevelsAlertConfigurationApi)
     async def find_alert_config_versions(self,
         id: str,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Find all versions of an SLO alert configuration."""
         try:
@@ -516,8 +518,8 @@ class SLOAlertConfigMCPTools(BaseInstanaClient):
     @with_header_auth(ServiceLevelsAlertConfigurationApi)
     async def create_alert_config(self,
         payload: Union[Dict[str, Any], str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Create new SLO alert configuration."""
         try:
@@ -563,8 +565,8 @@ class SLOAlertConfigMCPTools(BaseInstanaClient):
     async def update_alert_config(self,
         id: str,
         payload: Union[Dict[str, Any], str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Update existing SLO alert configuration."""
         try:
@@ -619,8 +621,8 @@ class SLOAlertConfigMCPTools(BaseInstanaClient):
     @with_header_auth(ServiceLevelsAlertConfigurationApi)
     async def delete_alert_config(self,
         id: str,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Delete SLO alert configuration."""
         try:
@@ -639,8 +641,8 @@ class SLOAlertConfigMCPTools(BaseInstanaClient):
     @with_header_auth(ServiceLevelsAlertConfigurationApi)
     async def disable_alert_config(self,
         id: str,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Disable SLO alert configuration."""
         try:
@@ -659,8 +661,8 @@ class SLOAlertConfigMCPTools(BaseInstanaClient):
     @with_header_auth(ServiceLevelsAlertConfigurationApi)
     async def enable_alert_config(self,
         id: str,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Enable SLO alert configuration."""
         try:
@@ -680,8 +682,8 @@ class SLOAlertConfigMCPTools(BaseInstanaClient):
     async def restore_alert_config(self,
         id: str,
         created: int,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Restore SLO alert configuration to a specific version by creation timestamp."""
         try:

--- a/src/slo/slo_configuration.py
+++ b/src/slo/slo_configuration.py
@@ -8,6 +8,8 @@ import json
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 # Import the necessary classes from the Instana SDK
 try:
     from instana_client.api.service_levels_objective_slo_configurations_api import (
@@ -298,8 +300,8 @@ class SLOConfigurationMCPTools(BaseInstanaClient):
         grouped: Optional[bool] = None,
         refresh: Optional[bool] = None,
         rbac_tags: Optional[List[str]] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Get all SLO configurations with optional filtering and pagination.
@@ -430,8 +432,8 @@ class SLOConfigurationMCPTools(BaseInstanaClient):
     @with_header_auth(ServiceLevelsObjectiveSLOConfigurationsApi)
     async def create_slo_config(self,
                                 payload: Union[Dict[str, Any], str],
-                                ctx=None,
-                                api_client=None) -> Dict[str, Any]:
+                                ctx: Optional[Context] = None,
+                                api_client: Any = None) -> Dict[str, Any]:
         """
         Create a new SLO configuration.
 
@@ -610,8 +612,8 @@ class SLOConfigurationMCPTools(BaseInstanaClient):
     async def update_slo_config(self,
                                 id: str,
                                 payload: Union[Dict[str, Any], str],
-                                ctx=None,
-                                api_client=None) -> Dict[str, Any]:
+                                ctx: Optional[Context] = None,
+                                api_client: Any = None) -> Dict[str, Any]:
         """
         Update an existing SLO configuration.
 
@@ -766,8 +768,8 @@ class SLOConfigurationMCPTools(BaseInstanaClient):
     @with_header_auth(ServiceLevelsObjectiveSLOConfigurationsApi)
     async def delete_slo_config(self,
                                 id: str,
-                                ctx=None,
-                                api_client=None) -> Dict[str, Any]:
+                                ctx: Optional[Context] = None,
+                                api_client: Any = None) -> Dict[str, Any]:
         """
         Delete an SLO configuration.
 
@@ -803,8 +805,8 @@ class SLOConfigurationMCPTools(BaseInstanaClient):
                                   query: Optional[str] = None,
                                   tag: Optional[List[str]] = None,
                                   entity_type: Optional[str] = None,
-                                  ctx=None,
-                                  api_client=None) -> Dict[str, Any]:
+                                  ctx: Optional[Context] = None,
+                                  api_client: Any = None) -> Dict[str, Any]:
         """
         Get all available tags for SLO configurations with optional filtering.
 

--- a/src/slo/slo_correction_configuration.py
+++ b/src/slo/slo_correction_configuration.py
@@ -9,6 +9,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
 from instana_client.models.correction_configuration import CorrectionConfiguration
 from instana_client.models.correction_scheduling import CorrectionScheduling
 
@@ -161,8 +162,8 @@ class SLOCorrectionMCPTools(BaseInstanaClient):
         id: Optional[List[str]]= None,
         slo_id: Optional[List[str]] = None,
         refresh: Optional[bool] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Get all SLO correction window configurations with optional filtering."""
         try:
@@ -197,7 +198,7 @@ class SLOCorrectionMCPTools(BaseInstanaClient):
     async def get_correction_by_id(self,
        id: str,
        ctx = None,
-       api_client=None
+       api_client: Any = None
     ) -> Dict[str, Any]:
         """Get a specific SLO correction window configuration by ID."""
         try:
@@ -221,8 +222,8 @@ class SLOCorrectionMCPTools(BaseInstanaClient):
     @with_header_auth(SLOCorrectionConfigurationsApi)
     async def create_correction(self,
         payload: Union[Dict[str, Any], str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Create new SLO correction window configuration."""
         try:
@@ -370,8 +371,8 @@ class SLOCorrectionMCPTools(BaseInstanaClient):
     @with_header_auth(SLOCorrectionConfigurationsApi)
     async def delete_correction(self,
         id: str,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Delete SLO correction window configuration."""
         try:

--- a/src/slo/slo_report.py
+++ b/src/slo/slo_report.py
@@ -8,6 +8,8 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
+from fastmcp import Context
+
 # Import the necessary classes from the Instana SDK
 try:
     from instana_client.api.service_levels_objective_slo_report_api import (
@@ -78,8 +80,8 @@ class SLOReportMCPTools(BaseInstanaClient):
         to: Optional[str] = None,
         exclude_correction_id: Optional[List[str]] = None,
         include_correction_id: Optional[List[str]] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Generate Service Levels report for a specific SLO configuration.

--- a/src/website/website_analyze.py
+++ b/src/website/website_analyze.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from email.message import Message
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 # Constants
 DEFAULT_CHARSET = 'utf-8'
 DEFAULT_GROUP_BY_TAG = 'beacon.location.path'  # Default grouping by URL path
@@ -98,8 +100,8 @@ class WebsiteAnalyzeMCPTools(BaseInstanaClient):
     fill_time_series: Optional[bool] = True,
     order: Optional[Dict[str, str]] = None,
     pagination: Optional[Dict[str, int]] = None,
-    ctx=None,
-    api_client=None) -> Dict[str, Any]:
+    ctx: Optional[Context] = None,
+    api_client: Any = None) -> Dict[str, Any]:
         """
         Get grouped website beacon metrics.
 
@@ -459,8 +461,8 @@ class WebsiteAnalyzeMCPTools(BaseInstanaClient):
         time_frame: Optional[Dict[str, int]] = None,
         beacon_type: Optional[str] = None,
         pagination: Optional[Dict[str, int]] = None,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Get website beacon metrics with pagination support.

--- a/src/website/website_catalog.py
+++ b/src/website/website_catalog.py
@@ -8,6 +8,8 @@ import logging
 from email.message import Message
 from typing import Any, Dict, List, Optional
 
+from fastmcp import Context
+
 # Import the necessary classes from the SDK
 try:
     from instana_client.api.website_catalog_api import WebsiteCatalogApi
@@ -66,7 +68,7 @@ class WebsiteCatalogMCPTools(BaseInstanaClient):
 
 
     @with_header_auth(WebsiteCatalogApi)
-    async def get_website_catalog_metrics(self, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def get_website_catalog_metrics(self, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get website monitoring metrics catalog.
 
@@ -123,7 +125,7 @@ class WebsiteCatalogMCPTools(BaseInstanaClient):
             return {"error": f"Failed to get website catalog metrics: {e!s}"}
 
     @with_header_auth(WebsiteCatalogApi)
-    async def get_website_catalog_tags(self, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def get_website_catalog_tags(self, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get website monitoring tags catalog.
 
@@ -173,7 +175,7 @@ class WebsiteCatalogMCPTools(BaseInstanaClient):
     async def get_website_tag_catalog(self,
                                     beacon_type: str,
                                     use_case: str,
-                                    ctx=None, api_client=None) -> Dict[str, Any]:
+                                    ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get website monitoring tag catalog.
 

--- a/src/website/website_configuration.py
+++ b/src/website/website_configuration.py
@@ -7,6 +7,8 @@ This module provides website configuration-specific MCP tools for Instana monito
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 # Import the necessary classes from the SDK
 try:
     from instana_client.api.website_configuration_api import WebsiteConfigurationApi
@@ -135,7 +137,7 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
             return {"error": f"Failed to execute advanced config operation: {e!s}"}
 
     @with_header_auth(WebsiteConfigurationApi)
-    async def _get_all_websites(self, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def _get_all_websites(self, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         return await self.get_websites(ctx=ctx, api_client=api_client)
 
     @with_header_auth(WebsiteConfigurationApi)
@@ -143,8 +145,8 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
         self,
         website_id: Optional[str],
         website_name: Optional[str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Get a specific website by ID or name."""
         # If website_name is provided but not website_id, resolve it
@@ -210,8 +212,8 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
         self,
         name: Optional[str],
         payload: Optional[Union[Dict, str]],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """ Create a new website. """
 
@@ -224,8 +226,8 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
     async def _delete_website(
         self,
         website_id: Optional[str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """ Delete a website. """
 
@@ -239,8 +241,8 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
         self,
         website_id: Optional[str],
         name: Optional[str],
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """Rename a website."""
         if not website_id:
@@ -251,7 +253,7 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
         return await self.rename_website(website_id=website_id, name=name, ctx=ctx, api_client=api_client)
 
     @with_header_auth(WebsiteConfigurationApi)
-    async def get_websites(self, ctx=None, api_client=None) -> List[Dict[str, Any]]:
+    async def get_websites(self, ctx: Optional[Context] = None, api_client: Any = None) -> List[Dict[str, Any]]:
         """
         Get all websites.
 
@@ -283,7 +285,7 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
             return [{"error": f"Failed to get websites: {e!s}"}]
 
     @with_header_auth(WebsiteConfigurationApi)
-    async def get_website(self, website_id: str, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def get_website(self, website_id: str, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get a specific website by ID.
 
@@ -319,8 +321,8 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
     async def create_website(self,
                             name: str,
                             payload: Optional[Union[List[Dict[str, Any]], str]] = None,
-                            ctx=None,
-                            api_client=None) -> Dict[str, Any]:
+                            ctx: Optional[Context] = None,
+                            api_client: Any = None) -> Dict[str, Any]:
         """
         Create a new website configuration.
 
@@ -420,7 +422,7 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
             return {"error": f"Failed to create website: {e!s}"}
 
     @with_header_auth(WebsiteConfigurationApi)
-    async def delete_website(self, website_id: str, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def delete_website(self, website_id: str, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Delete a website configuration.
 
@@ -449,8 +451,8 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
     async def rename_website(self,
                             website_id: str,
                             name: Optional[str] = None,
-                            ctx=None,
-                            api_client=None) -> Dict[str, Any]:
+                            ctx: Optional[Context] = None,
+                            api_client: Any = None) -> Dict[str, Any]:
         """
         Rename a website configuration.
 
@@ -490,8 +492,8 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
     @with_header_auth(WebsiteConfigurationApi)
     async def get_website_geo_location_configuration(self,
                                                     website_id: str,
-                                                    ctx=None,
-                                                    api_client=None) -> Dict[str, Any]:
+                                                    ctx: Optional[Context] = None,
+                                                    api_client: Any = None) -> Dict[str, Any]:
         """
         Get geo-location configuration for a website.
 
@@ -527,7 +529,7 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
     async def update_website_geo_location_configuration(self,
                                                         website_id: str,
                                                         payload: Union[Dict[str, Any], str],
-                                                        ctx=None, api_client=None) -> Dict[str, Any]:
+                                                        ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Update geo-location configuration for a website.
 
@@ -639,7 +641,7 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
             return {"error": f"Failed to update website geo-location configuration: {e!s}"}
 
     @with_header_auth(WebsiteConfigurationApi)
-    async def get_website_ip_masking_configuration(self, website_id: str, ctx=None, api_client=None) -> Dict[str, Any]:
+    async def get_website_ip_masking_configuration(self, website_id: str, ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get IP masking configuration for a website.
 
@@ -675,7 +677,7 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
     async def update_website_ip_masking_configuration(self,
                                                         website_id: str,
                                                         payload: Optional[Dict[str, Any]] = None,
-                                                        ctx=None, api_client=None) -> Dict[str, Any]:
+                                                        ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Update IP masking configuration for a website.
 
@@ -784,7 +786,7 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
             return {"error": f"Failed to update website ip-masking configuration: {e!s}"}
 
     @with_header_auth(WebsiteConfigurationApi)
-    async def get_website_geo_mapping_rules(self, website_id: str, ctx=None, api_client=None) -> List[Dict[str, Any]]:
+    async def get_website_geo_mapping_rules(self, website_id: str, ctx: Optional[Context] = None, api_client: Any = None) -> List[Dict[str, Any]]:
         """
        Get custom geo mapping rules for website
 
@@ -850,7 +852,7 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
     async def set_website_geo_mapping_rules(self,
                                             website_id: str,
                                             body: Optional[str] = None,
-                                            ctx=None, api_client=None) -> Dict[str, Any]:
+                                            ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Set custom geo mapping rules for website
 
@@ -897,7 +899,7 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
                                         file_format: Optional[str] = None,
                                         source_map: Optional[str] = None,
                                         url: Optional[str] = None,
-                                        ctx=None, api_client=None) -> Dict[str, Any]:
+                                        ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Upload source map file for a website.
 
@@ -951,7 +953,7 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
     async def clear_source_map_upload_configuration(self,
                                                     website_id: str,
                                                     source_map_config_id: str,
-                                                    ctx=None, api_client=None) -> Dict[str, Any]:
+                                                    ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
        Clear source map upload configuration for a website.
 
@@ -996,8 +998,8 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
         self,
         website_id: str,
         source_map_config_id: str,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Get a specific source map upload configuration for a website.
@@ -1061,8 +1063,8 @@ class WebsiteConfigurationMCPTools(BaseInstanaClient):
     async def get_website_source_map_upload_configurations(
         self,
         website_id: str,
-        ctx=None,
-        api_client=None
+        ctx: Optional[Context] = None,
+        api_client: Any = None
     ) -> Dict[str, Any]:
         """
         Get all source map upload configurations for a website.

--- a/src/website/website_metrics.py
+++ b/src/website/website_metrics.py
@@ -8,6 +8,8 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 # Import the necessary classes from the SDK
 try:
     from instana_client.api.website_metrics_api import WebsiteMetricsApi
@@ -36,7 +38,7 @@ class WebsiteMetricsMCPTools(BaseInstanaClient):
     async def get_website_page_load(self,
                                    page_id: str,
                                    timestamp: int,
-                                   ctx=None, api_client=None) -> List[Dict[str, Any]]:
+                                   ctx: Optional[Context] = None, api_client: Any = None) -> List[Dict[str, Any]]:
         """
         Get website monitoring beacons for a specific page load.
 
@@ -89,7 +91,7 @@ class WebsiteMetricsMCPTools(BaseInstanaClient):
     @with_header_auth(WebsiteMetricsApi)
     async def get_website_beacon_metrics_v2(self,
                                            payload: Optional[Union[Dict[str, Any], str]] = None,
-                                           ctx=None, api_client=None) -> Dict[str, Any]:
+                                           ctx: Optional[Context] = None, api_client: Any = None) -> Dict[str, Any]:
         """
         Get website beacon metrics using the v2 API.
 


### PR DESCRIPTION
## Summary
This PR removes internal parameters (`ctx`, `api_client`) from published MCP tool schemas to resolve Pydantic v2 validation errors encountered by clients generating models from the schema (e.g., LangSmith agents).

## Problem
Tool methods exposed internal parameters in their JSON schemas, which caused validation failures when clients attempted to construct Pydantic models.

Example error:
1 validation error for Schema
properties.ctx
Input should be a valid dictionary or object to extract fields from

## Root Cause
Internal parameters were defined without type annotations:

```python
async def get_all_releases(self, from_time=None, to_time=None, ctx=None, api_client=None):
```
FastMCP only excludes parameters annotated with Context. Without typing, invalid schema entries were generated.

## Solution

- Added type annotations across tool methods:
1. ctx=None → ctx: Optional[Context] = None
2. api_client=None → api_client: Any = None

- Enhanced with_header_auth decorator to exclude api_client from published signatures using inspect.signature

- Fixed import ordering for ruff compliance

## Scope of Changes

- Updated router files (releases, slo, application, automation, events, custom_dashboard, website)
- Updated 30+ tool files across modules
- Modified src/core/utils.py