### PR TITLE
fix: Corrected the rendering of topology of root cause analysis

### DIFF
--- a/src/event/events_tools.py
+++ b/src/event/events_tools.py
@@ -317,23 +317,87 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
 
         # Extract key information
         confidence = primary_cause.get("probFailure", 0)
-        entity_label = primary_cause.get("entityLabel", "Unknown")
-        entity_type = primary_cause.get("entityType", "")
 
-        # Try to create a meaningful summary from explainability
+        topology = primary_cause.get("topology", {})
+        shortest_path = topology.get("shortestPath", [])
+
+        # Build a pluginId-suffix → readable type map
+        _PLUGIN_TYPE_MAP = {
+            "Service": "Service",
+            "Endpoint": "Endpoint",
+            "Application": "Application",
+        }
+
+        def _node_type(node: Dict[str, Any]) -> str:
+            plugin_id = node.get("pluginId", "")
+            suffix = plugin_id.split(".")[-1] if plugin_id else ""
+            return _PLUGIN_TYPE_MAP.get(suffix, suffix)
+
+        if shortest_path:
+            # The last node in the shortest path is the root cause entity
+            rc_node = shortest_path[-1]
+            entity_type = _node_type(rc_node)
+        else:
+            # Fallback to entityID block
+            rc_node = None
+            entity_id = primary_cause.get("entityID", {})
+            plugin_id = entity_id.get("pluginId", "")
+            entity_type = _PLUGIN_TYPE_MAP.get(plugin_id.split(".")[-1], plugin_id.split(".")[-1]) if plugin_id else ""
+
+        # Build topology path as a list of objects so callers can use snapshotId / steadyId
+        # for further lookups (e.g. infrastructure snapshot queries).
+        topology_nodes = []
+        if shortest_path:
+            for node in shortest_path:
+                entry: Dict[str, Any] = {"type": _node_type(node), "steadyId": node.get("steadyId")}
+                if node.get("snapshotId"):
+                    entry["snapshotId"] = node.get("snapshotId")
+                topology_nodes.append(entry)
+
+        # Human-readable path string (e.g. "Service → Service → Service → Endpoint")
+        topology_path = " → ".join(n["type"] or n["steadyId"] or "?" for n in topology_nodes) if topology_nodes else ""
+
+        # Extract explainability stats — deduplicate on connectedServiceId, keep the
+        # entry that covers "all" traffic as the primary summary signal.
         summary = "Root cause identified"
         explainability = primary_cause.get("explainability", [])
-        if explainability and isinstance(explainability, list) and len(explainability) > 0:
-            first_explain = explainability[0]
-            if isinstance(first_explain, dict):
-                summary = first_explain.get("text", summary)
+        # Find the "all" entry first (most representative), fall back to first entry
+        primary_explain = next(
+            (e for e in explainability if isinstance(e, dict) and e.get("connectedServiceId") == "all"),
+            explainability[0] if explainability and isinstance(explainability[0], dict) else None,
+        )
+        if primary_explain:
+            pct_through = primary_explain.get("percentageFailedThroughRC")
+            pct_not_through = primary_explain.get("percentageFailedNotThroughRC")
+            calls_through = primary_explain.get("numCallsInAggregationThroughRC")
+            calls_not_through = primary_explain.get("numCallsInAggregationNotThroughRC")
+            if pct_through is not None and pct_not_through is not None:
+                summary = (
+                    f"{int(pct_through * 100)}% of calls through root cause failed "
+                    f"vs {int(pct_not_through * 100)}% not through it"
+                )
+                if calls_through is not None and calls_not_through is not None:
+                    summary += f" ({calls_through} calls through RC, {calls_not_through} not through RC)"
+            else:
+                summary = primary_explain.get("text", summary)
 
-        return {
+        rc_entity: Dict[str, Any] = {
+            "type": entity_type,
+            "steadyId": rc_node.get("steadyId") if shortest_path else (primary_cause.get("entityID") or {}).get("steadyId"),
+        }
+        if shortest_path and rc_node.get("snapshotId"):
+            rc_entity["snapshotId"] = rc_node.get("snapshotId")
+
+        result: Dict[str, Any] = {
             "found": True,
             "confidence": round(confidence, 2),
-            "rootCauseEntity": f"{entity_type}: {entity_label}" if entity_type else entity_label,
-            "summary": summary
+            "rootCauseEntity": rc_entity,
+            "summary": summary,
         }
+        if topology_nodes:
+            result["topologyPath"] = topology_path
+            result["topologyNodes"] = topology_nodes
+        return result
 
     def _optimize_event_data(self, event: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -409,10 +473,16 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
                 if event.get("mobileAppId"):
                     optimized["entity"]["mobileAppId"] = event.get("mobileAppId")
 
-            # Simplify metrics to just names (skip if empty, which is common for agent monitoring)
+            # Simplify metrics to just names (skip if empty, which is common for agent monitoring).
+            # The API may return metrics as plain strings or as {"metricName": ...} dicts.
             metrics = event.get("metrics", [])
-            if metrics and len(metrics) > 0:
-                metric_names = [m.get("metricName") for m in metrics if m.get("metricName")]
+            if metrics:
+                metric_names = []
+                for m in metrics:
+                    if isinstance(m, str):
+                        metric_names.append(m)
+                    elif isinstance(m, dict) and m.get("metricName"):
+                        metric_names.append(m["metricName"])
                 if metric_names:
                     optimized["affectedMetrics"] = metric_names
 
@@ -514,64 +584,42 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
             if not event_id:
                 return {"error": "event_id parameter is required"}
 
-            # Try standard API call first
+            # Use the raw response path directly to avoid Pydantic model
+            # validation errors in the SDK's ServiceEventResult model, which
+            # rejects the flat primitive shapes the API actually returns for
+            # fields like `metrics`, `recentEvents`, and `probableCause.found`.
             try:
-                result = api_client.get_event(event_id=event_id)
+                response_data = api_client.get_event_without_preload_content(event_id=event_id)
 
-                # New robust conversion to dict
-                if hasattr(result, "to_dict"):
-                    result_dict = result.to_dict()
-                elif isinstance(result, dict):
-                    result_dict = result
-                else:
-                    # Convert to dictionary using __dict__ or as a fallback, create a new dict with string representation
-                    result_dict = getattr(result, "__dict__", {"data": str(result)})
+                if response_data.status == 404:
+                    return {"error": f"Event with ID {event_id} not found", "event_id": event_id}
+                elif response_data.status in (401, 403):
+                    return {"error": "Authentication failed. Please check your API token and permissions."}
+                elif response_data.status != 200:
+                    error_message = f"Failed to get event: HTTP {response_data.status}"
+                    logger.error(error_message)
+                    return {"error": error_message, "event_id": event_id}
 
-                # Optimize event data to reduce token usage
+                response_text = response_data.data.decode('utf-8')
+
+                try:
+                    result_dict = json.loads(response_text)
+                except json.JSONDecodeError as json_err:
+                    error_message = f"Failed to parse JSON response: {json_err}"
+                    logger.error(error_message)
+                    return {"error": error_message, "event_id": event_id}
+
                 optimized_result = self._optimize_event_data(result_dict)
-
                 logger.debug(f"Successfully retrieved event with ID {event_id}")
                 return optimized_result
 
             except Exception as api_error:
-                # Check for specific error types
                 if hasattr(api_error, 'status'):
                     if api_error.status == 404:
                         return {"error": f"Event with ID {event_id} not found", "event_id": event_id}
                     elif api_error.status in (401, 403):
                         return {"error": "Authentication failed. Please check your API token and permissions."}
-
-                # Try fallback approach
-                logger.warning(f"Standard API call failed: {api_error}, trying fallback approach")
-
-                # Use the without_preload_content version to get the raw response
-                try:
-                    response_data = api_client.get_event_without_preload_content(event_id=event_id)
-
-                    # Check if the response was successful
-                    if response_data.status != 200:
-                        error_message = f"Failed to get event: HTTP {response_data.status}"
-                        logger.error(error_message)
-                        return {"error": error_message, "event_id": event_id}
-
-                    # Read the response content
-                    response_text = response_data.data.decode('utf-8')
-
-                    # Parse the JSON manually
-                    try:
-                        result_dict = json.loads(response_text)
-                        # Optimize event data to reduce token usage
-                        optimized_result = self._optimize_event_data(result_dict)
-                        logger.debug(f"Successfully retrieved event with ID {event_id} using fallback")
-                        return optimized_result
-                    except json.JSONDecodeError as json_err:
-                        error_message = f"Failed to parse JSON response: {json_err}"
-                        logger.error(error_message)
-                        return {"error": error_message, "event_id": event_id}
-
-                except Exception as fallback_error:
-                    logger.error(f"Fallback approach failed: {fallback_error}")
-                    raise
+                raise
 
         except Exception as e:
             logger.error(f"Error in get_event: {e}", exc_info=True)

--- a/tests/e2e/event/test_events_tools.py
+++ b/tests/e2e/event/test_events_tools.py
@@ -93,12 +93,9 @@ class TestAgentMonitoringEventsE2E:
     async def test_get_event_error(self, mock_events_api, instana_credentials):
         """Test error handling when getting an event by ID."""
 
-        # Create a mock API client that raises an exception
+        # Create a mock API client that raises an ApiException with status=404
         mock_api_client = MagicMock()
-        # Set up the mock to return a 404 error
-        mock_api_client.get_event.side_effect = ApiException(status=404, reason="Not Found")
-        # Mock the fallback approach to also fail
-        mock_api_client.get_event_without_preload_content.side_effect = Exception("Fallback error")
+        mock_api_client.get_event_without_preload_content.side_effect = ApiException(status=404, reason="Not Found")
 
         # Create the client
         client = AgentMonitoringEventsMCPTools(
@@ -1591,57 +1588,41 @@ class TestAgentMonitoringEventsE2E:
     @pytest.mark.mocked
     @patch('src.event.events_tools.EventsApi')
     async def test_get_event_with_various_response_formats(self, mock_events_api, instana_credentials):
-        """Test get_event with various response formats."""
-        # Create different mock responses
-        standard_response = MagicMock()
-        standard_response.to_dict.return_value = {
-            "eventId": "event-123",
-            "type": "incident",
-            "severity": 10
-        }
+        """Test get_event with various response formats via the raw API path."""
 
-        minimal_response = MagicMock()
-        minimal_response.to_dict.return_value = {
-            "eventId": "event-456"
-        }
-
-        detailed_response = MagicMock()
-        detailed_response.to_dict.return_value = {
-            "eventId": "event-789",
-            "type": "incident",
-            "severity": 10,
-            "start": 1625097600000,
-            "end": 1625097900000,
-            "entityId": "entity-123",
-            "entityName": "host-1",
-            "entityLabel": "host-1.example.com",
-            "problem": "High CPU Usage",
-            "detail": "CPU usage exceeded 90% for 5 minutes",
-            "fixSuggestion": "Check for runaway processes",
-            "metrics": [
-                {"metricName": "cpu.usage", "value": 95.5, "unit": "%"}
-            ],
-            "tags": {
-                "host.name": "host-1",
-                "zone": "us-east-1"
-            }
-        }
+        def make_raw_response(payload, status=200):
+            r = MagicMock()
+            r.status = status
+            r.data = json.dumps(payload).encode("utf-8")
+            return r
 
         # Create a mock API client
         mock_api_client = MagicMock()
 
-        # Set up the mock to return different responses based on event ID
-        def get_event_side_effect(event_id, **kwargs):
+        # Set up the raw-response mock to return different payloads based on event ID
+        def get_event_without_preload_side_effect(event_id, **kwargs):
             if event_id == "event-123":
-                return standard_response
+                return make_raw_response({"eventId": "event-123", "type": "incident", "severity": 10})
             elif event_id == "event-456":
-                return minimal_response
+                return make_raw_response({"eventId": "event-456"})
             elif event_id == "event-789":
-                return detailed_response
+                return make_raw_response({
+                    "eventId": "event-789",
+                    "type": "incident",
+                    "severity": 10,
+                    "start": 1625097600000,
+                    "end": 1625097900000,
+                    "entityLabel": "host-1.example.com",
+                    "entityType": "host",
+                    "problem": "High CPU Usage",
+                    "detail": "CPU usage exceeded 90% for 5 minutes",
+                    "fixSuggestion": "Check for runaway processes",
+                    "metrics": [{"metricName": "cpu.usage", "value": 95.5, "unit": "%"}],
+                })
             else:
-                raise ApiException(status=404, reason="Not Found")
+                return make_raw_response({}, status=404)
 
-        mock_api_client.get_event.side_effect = get_event_side_effect
+        mock_api_client.get_event_without_preload_content.side_effect = get_event_without_preload_side_effect
 
         # Create the client
         client = AgentMonitoringEventsMCPTools(
@@ -1655,24 +1636,21 @@ class TestAgentMonitoringEventsE2E:
         result3 = await client.get_event(event_id="event-789", api_client=mock_api_client)
         result4 = await client.get_event(event_id="non-existent", api_client=mock_api_client)
 
-        # Verify standard response - get_event now runs _optimize_event_data
+        # Verify standard response
         assert isinstance(result1, dict)
         assert result1.get("type") == "incident"
         assert result1.get("severity") == 10
 
-        # Verify minimal response - _optimize_event_data returns base structure
-        assert isinstance(result2, dict)
+        # Verify minimal response returns base structure
         assert isinstance(result2, dict)
 
-        # Verify detailed response - _optimize_event_data transforms the structure
+        # Verify detailed response is transformed correctly
         assert isinstance(result3, dict)
         assert result3.get("type") == "incident"
         assert result3.get("problem") == "High CPU Usage"
         assert result3.get("start") == 1625097600000
-        # _optimize_event_data includes entity info for incidents
         assert "entity" in result3
         assert result3["entity"]["label"] == "host-1.example.com"
-        # detail and fixSuggestion are included when non-empty
         assert result3.get("detail") == "CPU usage exceeded 90% for 5 minutes"
         assert result3.get("fixSuggestion") == "Check for runaway processes"
 
@@ -1893,34 +1871,21 @@ class TestAgentMonitoringEventsE2E:
     @pytest.mark.mocked
     @patch('src.event.events_tools.EventsApi')
     async def test_get_event_to_dict_conversion(self, mock_events_api, instana_credentials):
-        """Test get_event with to_dict conversion"""
-        # Create a mock API client
+        """Test get_event returns incident fields via the raw API path."""
         mock_api_client = MagicMock()
-
-        # Create a mock response with to_dict method
         mock_response = MagicMock()
-        mock_response.to_dict.return_value = {
-            "id": "event-123",
-            "type": "incident",
-            "severity": 10
-        }
+        mock_response.status = 200
+        mock_response.data = json.dumps({"eventId": "event-123", "type": "incident", "severity": 10}).encode("utf-8")
+        mock_api_client.get_event_without_preload_content.return_value = mock_response
 
-        # Set up the mock to return the mock response
-        mock_api_client.get_event.return_value = mock_response
-
-        # Create the client
         client = AgentMonitoringEventsMCPTools(
             read_token=instana_credentials["api_token"],
             base_url=instana_credentials["base_url"]
         )
 
-        # Test the method
         result = await client.get_event(event_id="event-123", api_client=mock_api_client)
 
-        # Verify the result contains the expected data
-        # get_event now runs _optimize_event_data which transforms the structure
         assert isinstance(result, dict)
-        # _optimize_event_data preserves type and severity for incidents
         assert result.get("type") == "incident"
         assert result.get("severity") == 10
 
@@ -1928,33 +1893,21 @@ class TestAgentMonitoringEventsE2E:
     @pytest.mark.mocked
     @patch('src.event.events_tools.EventsApi')
     async def test_get_event_dict_conversion(self, mock_events_api, instana_credentials):
-        """Test get_event with dict conversion"""
-        # Create a mock API client
+        """Test get_event with a dict-shaped raw response."""
         mock_api_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.data = json.dumps({"eventId": "event-123", "type": "incident", "severity": 10}).encode("utf-8")
+        mock_api_client.get_event_without_preload_content.return_value = mock_response
 
-        # Create a mock response as a dictionary
-        mock_response = {
-            "id": "event-123",
-            "type": "incident",
-            "severity": 10
-        }
-
-        # Set up the mock to return the mock response
-        mock_api_client.get_event.return_value = mock_response
-
-        # Create the client
         client = AgentMonitoringEventsMCPTools(
             read_token=instana_credentials["api_token"],
             base_url=instana_credentials["base_url"]
         )
 
-        # Test the method
         result = await client.get_event(event_id="event-123", api_client=mock_api_client)
 
-        # Verify the result contains the expected data
-        # get_event now runs _optimize_event_data which transforms the structure
         assert isinstance(result, dict)
-        # _optimize_event_data preserves type and severity for incidents
         assert result.get("type") == "incident"
         assert result.get("severity") == 10
 
@@ -1962,35 +1915,30 @@ class TestAgentMonitoringEventsE2E:
     @pytest.mark.mocked
     @patch('src.event.events_tools.EventsApi')
     async def test_get_event_other_conversion(self, mock_events_api, instana_credentials):
-        """Test get_event with other object conversion"""
-        # Create a mock API client
+        """Test get_event with an incident response that includes start/end."""
         mock_api_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.data = json.dumps({
+            "eventId": "event-123",
+            "type": "incident",
+            "severity": 10,
+            "start": 1625097600000,
+            "end": 1625097900000,
+            "problem": "High CPU",
+            "state": "open",
+            "entityLabel": "host-1",
+            "entityType": "host",
+        }).encode("utf-8")
+        mock_api_client.get_event_without_preload_content.return_value = mock_response
 
-        # Create a mock response as a custom object with __dict__
-        class CustomResponse:
-            def __init__(self):
-                self.id = "event-123"
-                self.type = "incident"
-                self.severity = 10
-
-        mock_response = CustomResponse()
-
-        # Set up the mock to return the mock response
-        mock_api_client.get_event.return_value = mock_response
-
-        # Create the client
         client = AgentMonitoringEventsMCPTools(
             read_token=instana_credentials["api_token"],
             base_url=instana_credentials["base_url"]
         )
 
-        # Test the method
         result = await client.get_event(event_id="event-123", api_client=mock_api_client)
 
-        # Verify the result contains the expected data
-        # get_event now runs _optimize_event_data which transforms the structure
-        # CustomResponse.__dict__ gives {"id": "event-123", "type": "incident", "severity": 10}
-        # _optimize_event_data processes this and returns optimized structure
         assert isinstance(result, dict)
         assert result.get("type") == "incident"
         assert result.get("severity") == 10

--- a/tests/event/test_events_tools.py
+++ b/tests/event/test_events_tools.py
@@ -120,165 +120,103 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
         self.assertEqual(self.client.base_url, self.base_url)
 
     def test_get_event_success(self):
-        """Test get_event with a successful response"""
-        # Set up the mock response - include fields that survive _optimize_event_data
+        """Test get_event with a successful response via the raw API path."""
         event_id = "test_event_id"
-        mock_result = {"eventId": event_id, "data": "test_data", "type": "incident", "state": "open", "problem": "Test problem", "start": 1000000}
-        self.events_api.get_event.return_value = mock_result
-
-        # Call the method
-        result = asyncio.run(self.client.get_event(event_id=event_id))
-
-        # Check that the mock was called with the correct arguments
-        self.events_api.get_event.assert_called_once_with(event_id=event_id)
-
-        # Check that the result contains the event ID and key fields
-        # Note: get_event now runs _optimize_event_data which transforms the structure
-        self.assertEqual(result["eventId"], event_id)
-        self.assertIn("type", result)
-        self.assertIn("problem", result)
-
-    def test_get_event_error(self):
-        """Test get_event error handling"""
-        # Set up the mock to raise an exception
-        event_id = "test_event_id"
-        self.events_api.get_event.side_effect = Exception("Test error")
-
-        # Call the method and store result for assertions
-        result = asyncio.run(self.client.get_event(event_id=event_id))
-
-        # Check that the result contains an error message
-        self.assertIn("error", result)
-        self.assertIn("Failed to get event", result["error"])
-
-    def test_get_event_empty_id(self):
-        """Test get_event with empty event_id"""
-        # Call the method with empty event_id and store result for assertions
-        result = asyncio.run(self.client.get_event(event_id=""))
-
-        # Check that the result contains an error message
-        self.assertIn("error", result)
-        self.assertEqual(result["error"], "event_id parameter is required")
-
-    def test_get_event_404_error(self):
-        """Test get_event with 404 error"""
-        # Create a mock error with status attribute
-        class MockError(Exception):
-            def __init__(self):
-                self.status = 404
-
-        mock_error = MockError()
-
-        # Set up the mock to raise the error
-        event_id = "nonexistent_id"
-        self.events_api.get_event.side_effect = mock_error
-
-        # Call the method and store result for assertions
-        result = asyncio.run(self.client.get_event(event_id=event_id))
-
-        # Check that the result contains the expected error message
-        self.assertIn("error", result)
-        self.assertEqual(result["error"], f"Event with ID {event_id} not found")
-        self.assertEqual(result["event_id"], event_id)
-
-    def test_get_event_401_error(self):
-        """Test get_event with 401 error"""
-        # Create a mock error with status attribute
-        class MockError(Exception):
-            def __init__(self):
-                self.status = 401
-
-        mock_error = MockError()
-
-        # Set up the mock to raise the error
-        event_id = "test_id"
-        self.events_api.get_event.side_effect = mock_error
-
-        # Call the method and store result for assertions
-        result = asyncio.run(self.client.get_event(event_id=event_id))
-
-        # Check that the result contains the expected error message
-        self.assertIn("error", result)
-        self.assertEqual(result["error"], "Authentication failed. Please check your API token and permissions.")
-
-    def test_get_event_fallback_success(self):
-        """Test get_event fallback approach success"""
-        # Set up the mock to raise an exception for standard API
-        event_id = "test_event_id"
-        self.events_api.get_event.side_effect = Exception("Test error")
-
-        # Set up the mock response for fallback approach - include fields that survive _optimize_event_data
         mock_response = MagicMock()
         mock_response.status = 200
         mock_response.data = b'{"eventId": "test_event_id", "type": "incident", "state": "open", "problem": "Test problem", "start": 1000000}'
         self.events_api.get_event_without_preload_content.return_value = mock_response
 
-        # Call the method
         result = asyncio.run(self.client.get_event(event_id=event_id))
 
-        # Check that the fallback approach was used
         self.events_api.get_event_without_preload_content.assert_called_once_with(event_id=event_id)
-
-        # Check that the result contains the expected data
-        # Note: get_event now runs _optimize_event_data which transforms the structure
-        self.assertEqual(result["eventId"], "test_event_id")
+        self.assertEqual(result["eventId"], event_id)
         self.assertIn("type", result)
         self.assertIn("problem", result)
 
-    def test_get_event_fallback_http_error(self):
-        """Test get_event fallback approach with HTTP error"""
-        # Set up the mock to raise an exception for standard API
+    def test_get_event_error(self):
+        """Test get_event error handling when the raw API call raises."""
         event_id = "test_event_id"
-        self.events_api.get_event.side_effect = Exception("Test error")
+        self.events_api.get_event_without_preload_content.side_effect = Exception("Test error")
 
-        # Set up the mock response for fallback approach with error status
+        result = asyncio.run(self.client.get_event(event_id=event_id))
+
+        self.assertIn("error", result)
+        self.assertIn("Failed to get event", result["error"])
+
+    def test_get_event_empty_id(self):
+        """Test get_event with empty event_id."""
+        result = asyncio.run(self.client.get_event(event_id=""))
+
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "event_id parameter is required")
+
+    def test_get_event_404_error(self):
+        """Test get_event returns a not-found message on HTTP 404."""
+        event_id = "nonexistent_id"
         mock_response = MagicMock()
         mock_response.status = 404
         self.events_api.get_event_without_preload_content.return_value = mock_response
 
-        # Call the method and store result for assertions
         result = asyncio.run(self.client.get_event(event_id=event_id))
 
-        # Check that the result contains the expected error message
         self.assertIn("error", result)
-        self.assertEqual(result["error"], "Failed to get event: HTTP 404")
+        self.assertEqual(result["error"], f"Event with ID {event_id} not found")
         self.assertEqual(result["event_id"], event_id)
 
-    def test_get_event_fallback_json_error(self):
-        """Test get_event fallback approach with JSON decode error"""
-        # Set up the mock to raise an exception for standard API
-        event_id = "test_event_id"
-        self.events_api.get_event.side_effect = Exception("Test error")
+    def test_get_event_401_error(self):
+        """Test get_event returns auth error on HTTP 401."""
+        event_id = "test_id"
+        mock_response = MagicMock()
+        mock_response.status = 401
+        self.events_api.get_event_without_preload_content.return_value = mock_response
 
-        # Set up the mock response for fallback approach with invalid JSON
+        result = asyncio.run(self.client.get_event(event_id=event_id))
+
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "Authentication failed. Please check your API token and permissions.")
+
+    def test_get_event_http_error(self):
+        """Test get_event returns error on non-200/non-404 HTTP status."""
+        event_id = "test_event_id"
+        mock_response = MagicMock()
+        mock_response.status = 500
+        self.events_api.get_event_without_preload_content.return_value = mock_response
+
+        result = asyncio.run(self.client.get_event(event_id=event_id))
+
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "Failed to get event: HTTP 500")
+        self.assertEqual(result["event_id"], event_id)
+
+    def test_get_event_json_error(self):
+        """Test get_event returns error when response body is not valid JSON."""
+        event_id = "test_event_id"
         mock_response = MagicMock()
         mock_response.status = 200
         mock_response.data = b'invalid json'
         self.events_api.get_event_without_preload_content.return_value = mock_response
 
-        # Call the method and store result for assertions
         result = asyncio.run(self.client.get_event(event_id=event_id))
 
-        # Check that the result contains the expected error message
         self.assertIn("error", result)
         self.assertIn("Failed to parse JSON response", result["error"])
         self.assertEqual(result["event_id"], event_id)
 
-    def test_get_event_fallback_error(self):
-        """Test get_event fallback approach with error"""
-        # Set up the mock to raise an exception for standard API
-        event_id = "test_event_id"
-        self.events_api.get_event.side_effect = Exception("Test error")
+    def test_get_event_api_exception(self):
+        """Test get_event when the API raises an exception with a status attribute."""
+        class MockError(Exception):
+            def __init__(self):
+                self.status = 404
 
-        # Set up the mock to raise an exception for fallback approach
-        self.events_api.get_event_without_preload_content.side_effect = Exception("Fallback error")
+        event_id = "nonexistent_id"
+        self.events_api.get_event_without_preload_content.side_effect = MockError()
 
-        # Call the method and store result for assertions
         result = asyncio.run(self.client.get_event(event_id=event_id))
 
-        # Check that the result contains the expected error message
         self.assertIn("error", result)
-        self.assertIn("Failed to get event", result["error"])
+        self.assertEqual(result["error"], f"Event with ID {event_id} not found")
+        self.assertEqual(result["event_id"], event_id)
 
     @patch('src.event.events_tools.datetime')
     def test_get_kubernetes_info_events_with_defaults(self, mock_datetime):
@@ -1259,8 +1197,10 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
             "found": True,
             "currentRootCause": [{
                 "probFailure": 0.95,
-                "entityLabel": "my-service",
-                "entityType": "service",
+                "entityID": {
+                    "pluginId": "com.instana.plugin.service",
+                    "steadyId": "svc-steady-1"
+                },
                 "explainability": [{"text": "High error rate detected"}]
             }]
         }
@@ -1268,7 +1208,7 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertTrue(result["found"])
         self.assertEqual(result["confidence"], 0.95)
-        self.assertEqual(result["rootCauseEntity"], "service: my-service")
+        self.assertEqual(result["rootCauseEntity"], {"type": "service", "steadyId": "svc-steady-1"})
         self.assertEqual(result["summary"], "High error rate detected")
 
     def test_simplify_probable_cause_without_entity_type(self):
@@ -1277,15 +1217,149 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
             "found": True,
             "currentRootCause": [{
                 "probFailure": 0.85,
-                "entityLabel": "my-entity",
-                "entityType": "",
+                "entityID": {
+                    "pluginId": "",
+                    "steadyId": "entity-steady-1"
+                },
                 "explainability": []
             }]
         }
         result = self.client._simplify_probable_cause(probable_cause)
         self.assertIsNotNone(result)
-        self.assertEqual(result["rootCauseEntity"], "my-entity")
+        self.assertEqual(result["rootCauseEntity"], {"type": "", "steadyId": "entity-steady-1"})
         self.assertEqual(result["summary"], "Root cause identified")
+
+    def test_simplify_probable_cause_with_shortest_path(self):
+        """Root cause entity type is taken from the last node's pluginId; topologyNodes carry snapshotId/steadyId."""
+        probable_cause = {
+            "found": True,
+            "currentRootCause": [{
+                "probFailure": 0.95,
+                "topology": {
+                    "shortestPath": [
+                        {"pluginId": "com.instana.plugin.service", "steadyId": "svc-1", "snapshotId": "snap-1"},
+                        {"pluginId": "com.instana.plugin.database", "steadyId": "db-1", "snapshotId": "snap-2"},
+                        {"pluginId": "com.instana.plugin.endpoint", "steadyId": "ep-1", "snapshotId": "snap-3"},
+                    ]
+                },
+                "explainability": []
+            }]
+        }
+        result = self.client._simplify_probable_cause(probable_cause)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["rootCauseEntity"], {"type": "endpoint", "steadyId": "ep-1", "snapshotId": "snap-3"})
+        self.assertEqual(result["topologyPath"], "service → database → endpoint")
+        self.assertEqual(len(result["topologyNodes"]), 3)
+        self.assertEqual(result["topologyNodes"][2], {"type": "endpoint", "steadyId": "ep-1", "snapshotId": "snap-3"})
+
+    def test_simplify_probable_cause_topology_path_uses_steady_id_fallback(self):
+        """topologyPath uses type (from pluginId) when nodes have no label; topologyNodes carry steadyId."""
+        probable_cause = {
+            "found": True,
+            "currentRootCause": [{
+                "probFailure": 0.8,
+                "topology": {
+                    "shortestPath": [
+                        {"pluginId": "com.instana.plugin.service", "steadyId": "svc-abc"},
+                        {"pluginId": "com.instana.plugin.endpoint", "steadyId": "ep-xyz"},
+                    ]
+                },
+                "explainability": []
+            }]
+        }
+        result = self.client._simplify_probable_cause(probable_cause)
+        self.assertEqual(result["topologyPath"], "service → endpoint")
+        self.assertEqual(result["rootCauseEntity"], {"type": "endpoint", "steadyId": "ep-xyz"})
+        self.assertEqual(result["topologyNodes"][0]["steadyId"], "svc-abc")
+        self.assertEqual(result["topologyNodes"][1]["steadyId"], "ep-xyz")
+
+    def test_simplify_probable_cause_topology_path_uses_plugin_id_fallback(self):
+        """Nodes with neither label nor steadyId still produce a type-based topology path."""
+        probable_cause = {
+            "found": True,
+            "currentRootCause": [{
+                "probFailure": 0.7,
+                "topology": {
+                    "shortestPath": [
+                        {"pluginId": "com.instana.plugin.host"},
+                        {"pluginId": "com.instana.plugin.process"},
+                    ]
+                },
+                "explainability": []
+            }]
+        }
+        result = self.client._simplify_probable_cause(probable_cause)
+        self.assertEqual(result["topologyPath"], "host → process")
+
+    def test_simplify_probable_cause_no_topology_path_in_result(self):
+        """topologyPath and topologyNodes keys are absent when shortestPath is empty."""
+        probable_cause = {
+            "found": True,
+            "currentRootCause": [{
+                "probFailure": 0.9,
+                "entityID": {"pluginId": "com.instana.plugin.service", "steadyId": "svc-steady-9"},
+                "explainability": []
+            }]
+        }
+        result = self.client._simplify_probable_cause(probable_cause)
+        self.assertNotIn("topologyPath", result)
+        self.assertNotIn("topologyNodes", result)
+
+    def test_simplify_probable_cause_with_percentage_explainability(self):
+        """Summary uses failure-rate percentages when both fields are present."""
+        probable_cause = {
+            "found": True,
+            "currentRootCause": [{
+                "probFailure": 0.95,
+                "entityID": {"pluginId": "com.instana.plugin.endpoint", "steadyId": "ep-steady-1"},
+                "explainability": [{
+                    "percentageFailedThroughRC": 0.96,
+                    "percentageFailedNotThroughRC": 0.0
+                }]
+            }]
+        }
+        result = self.client._simplify_probable_cause(probable_cause)
+        self.assertIn("96% of calls through root cause failed vs 0% not through it", result["summary"])
+
+    def test_simplify_probable_cause_explainability_falls_back_to_text(self):
+        """Summary falls back to explainability text when percentages are absent."""
+        probable_cause = {
+            "found": True,
+            "currentRootCause": [{
+                "probFailure": 0.75,
+                "entityID": {"pluginId": "com.instana.plugin.service", "steadyId": "svc-steady-2"},
+                "explainability": [{"text": "Connection pool exhausted"}]
+            }]
+        }
+        result = self.client._simplify_probable_cause(probable_cause)
+        self.assertEqual(result["summary"], "Connection pool exhausted")
+
+    def test_simplify_probable_cause_entity_id_steady_id_fallback(self):
+        """entityID block exposes steadyId in rootCauseEntity dict."""
+        probable_cause = {
+            "found": True,
+            "currentRootCause": [{
+                "probFailure": 0.88,
+                "entityID": {"pluginId": "com.instana.plugin.database", "steadyId": "db-steady-123"},
+                "explainability": []
+            }]
+        }
+        result = self.client._simplify_probable_cause(probable_cause)
+        self.assertEqual(result["rootCauseEntity"], {"type": "database", "steadyId": "db-steady-123"})
+
+    def test_simplify_probable_cause_entity_id_unknown_fallback(self):
+        """rootCauseEntity steadyId is None when both label and steadyId are absent."""
+        probable_cause = {
+            "found": True,
+            "currentRootCause": [{
+                "probFailure": 0.6,
+                "entityID": {"pluginId": "com.instana.plugin.host"},
+                "explainability": []
+            }]
+        }
+        result = self.client._simplify_probable_cause(probable_cause)
+        self.assertEqual(result["rootCauseEntity"], {"type": "host", "steadyId": None})
+
 
     def test_optimize_event_data_with_detail_and_fix_suggestion(self):
         """Test _optimize_event_data includes detail and fixSuggestion when present."""
@@ -1476,27 +1550,22 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
         self.assertIn("entity", result)
         self.assertEqual(result["entity"]["label"], "Unknown service")
 
-    @mock_with_header_auth
-    def test_get_event_with_object_without_to_dict(self):
-        """Test get_event with an object that doesn't have to_dict method."""
-
-        class CustomObject:
-            def __init__(self):
-                self.eventId = "test-123"
-                self.type = "incident"
-                self.problem = "Test problem"
-                self.start = 1000000
-                self.end = 2000000
-                self.state = "closed"
-                self.entityLabel = "test-entity"
-                self.entityType = "service"
-
-        self.events_api.get_event.return_value = CustomObject()
-
-        result = asyncio.run(self.client.get_event(event_id="test-123"))
-
-        self.assertIn("eventId", result)
-        self.assertEqual(result["eventId"], "test-123")
+    def test_optimize_event_data_with_string_metrics(self):
+        """Test _optimize_event_data handles metrics returned as plain strings (live API shape)."""
+        event = {
+            "eventId": "test-123",
+            "type": "incident",
+            "state": "closed",
+            "problem": "High error rate",
+            "start": 1000000,
+            "end": 2000000,
+            "entityLabel": "my-service",
+            "entityType": "service",
+            "metrics": ["errors", "latency"],
+        }
+        result = self.client._optimize_event_data(event)
+        self.assertIn("affectedMetrics", result)
+        self.assertEqual(result["affectedMetrics"], ["errors", "latency"])
 
     def test_build_time_params_with_invalid_time_range(self):
         """Test _build_time_params with invalid time_range falls back to defaults."""
@@ -2177,4 +2246,3 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
Why
The previous implementation generated a probableCause block that lacked meaningful information, making it difficult for both the LLM and end users to understand the root cause. The Instana API already provides this information through the nested topology.shortestPath structure, but we were not extracting it correctly. As a result, the output often contained only internal IDs.This change traverses the shortestPath to extract the actual entity label and the propagation path. It also includes the failure-rate percentages from the explainability section, giving additional context on why the entity was identified as the probable cause. Together, these improvements make the probableCause block much more informative and allow the LLM to generate clearer, more actionable RCA responses.

What
Reworked _simplify_probable_cause() to improve root cause extraction.
Extract the root cause entity from topology.shortestPath, with fallback to entityID when unavailable.
Added a human-readable topologyPath by joining the entities in the propagation path.
Added an explainability-based summary using failure-rate percentages, with sensible fallbacks when the data is unavailable.
Updated the returned probableCause object to consistently include found, confidence, rootCauseEntity, and summary, with topologyPath included when available.

