### PR TITLE
INSTA-101709: Add MCP call tracking headers for segmentation in HTTP mode

### DIFF
--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -130,26 +130,6 @@ def register_as_tool(title=None, annotations=None, description=None):
 
     return decorator
 
-def _validate_http_headers(instana_token, instana_base_url):
-    """Validate HTTP mode headers."""
-    if not instana_token or not instana_base_url:
-        missing = []
-        if not instana_token:
-            missing.append("instana-api-token")
-        if not instana_base_url:
-            missing.append("instana-base-url")
-        error_msg = f"HTTP mode detected but missing required headers: {', '.join(missing)}"
-        print(f" {error_msg}", file=sys.stderr)
-        return {"error": error_msg}
-
-    if not instana_base_url.startswith("http://") and not instana_base_url.startswith("https://"):
-        error_msg = "Instana base URL must start with http:// or https://"
-        print(f" {error_msg}", file=sys.stderr)
-        return {"error": error_msg}
-
-    return None
-
-
 def _validate_http_auth_headers(instana_api_token, instana_jwt_token, instana_auth_token, instana_csrf_token, instana_base_url):
     """Validate HTTP authentication headers."""
     # Check for API token auth (needs token + base_url)
@@ -248,10 +228,11 @@ def _set_authorization_header(api_client_instance, auth_headers):
         logger.debug("Skipping Authorization header for API token (using SDK configuration)")
         return
 
-    # Set header for JWT Bearer tokens and other auth types
-    masked_value = _mask_token_for_logging(auth_header_value)
+    # Set header for JWT Bearer tokens and other auth types.
+    # Log only the scheme (e.g. "Bearer"), never any part of the token value.
+    scheme = auth_header_value.split(" ", 1)[0]
     api_client_instance.set_default_header("Authorization", auth_header_value)
-    logger.debug(f"Set Authorization header: {masked_value}")
+    logger.debug("Set Authorization header scheme: %s", scheme)
 
 
 def _set_csrf_headers(api_client_instance, auth_headers):
@@ -281,7 +262,77 @@ def _ssl_verify_from_env() -> bool:
     return raw not in ("0", "false", "no")
 
 
-def _create_api_client_with_config(base_url, instana_api_token, instana_jwt_token, auth_headers):
+def _get_ctx_session_id(ctx) -> Optional[str]:
+    """Return ctx.session_id as a string, or None if unavailable."""
+    try:
+        sid = ctx.session_id
+        return str(sid) if sid else None
+    except Exception:
+        return None
+
+
+def _get_ctx_request_id(ctx) -> Optional[str]:
+    """Return ctx.request_id as a string, or None if unavailable."""
+    try:
+        rid = ctx.request_id
+        return str(rid) if rid else None
+    except Exception:
+        return None
+
+
+def _get_ctx_client_name(ctx) -> Optional[str]:
+    """Return the LLM client name from the MCP initialize handshake, or None."""
+    try:
+        session = ctx.session
+        client_params = getattr(session, "client_params", None) if session else None
+        client_info = getattr(client_params, "clientInfo", None) if client_params else None
+        name = getattr(client_info, "name", None)
+        return str(name) if name else None
+    except Exception:
+        return None
+
+
+def _build_mcp_tracking_context(ctx=None, http_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    """Build MCP tracking headers for outgoing Instana API calls (HTTP mode).
+
+    Sources (all opportunistic — missing values are silently omitted):
+      ctx.session_id                         → X-MCP-Session-ID  (stable per conversation)
+      ctx.request_id                         → X-MCP-Request-ID  (unique per tool call)
+      ctx.session.client_params.clientInfo   → X-MCP-Client      (LLM product name from MCP handshake)
+      http_headers["x-mcp-user-id"]          → X-MCP-User-ID     (injected by upstream coordinator)
+    """
+    tracking: Dict[str, str] = {}
+
+    if ctx is not None:
+        sid = _get_ctx_session_id(ctx)
+        if sid:
+            tracking["X-MCP-Session-ID"] = sid
+
+        rid = _get_ctx_request_id(ctx)
+        if rid:
+            tracking["X-MCP-Request-ID"] = rid
+
+        client = _get_ctx_client_name(ctx)
+        if client:
+            tracking["X-MCP-Client"] = client
+
+    if http_headers:
+        user_id = http_headers.get("x-mcp-user-id", "")
+        if user_id:
+            tracking["X-MCP-User-ID"] = user_id
+
+    return tracking
+
+
+def _stamp_tracking_headers(api_client_instance, tracking: Dict[str, str]) -> None:
+    """Set MCP tracking headers on an SDK ApiClient as default headers."""
+    for name, value in tracking.items():
+        if value:
+            api_client_instance.set_default_header(name, value)
+
+
+def _create_api_client_with_config(base_url, instana_api_token, instana_jwt_token, auth_headers,
+                                    tracking: Optional[Dict[str, str]] = None):
     """Create API client with configuration based on auth type."""
     from instana_client.api_client import ApiClient
     from instana_client.configuration import Configuration
@@ -313,10 +364,14 @@ def _create_api_client_with_config(base_url, instana_api_token, instana_jwt_toke
     _set_authorization_header(api_client_instance, auth_headers)
     _set_csrf_headers(api_client_instance, auth_headers)
 
+    # Stamp MCP tracking headers so every outgoing Instana REST call carries them
+    if tracking:
+        _stamp_tracking_headers(api_client_instance, tracking)
+
     return api_client_instance, None
 
 
-def _try_http_mode_auth(api_class):
+def _try_http_mode_auth(api_class, tracking: Optional[Dict[str, str]] = None):
     """Attempt HTTP mode authentication."""
     try:
         from fastmcp.server.dependencies import get_http_headers
@@ -350,9 +405,16 @@ def _try_http_mode_auth(api_class):
             cookie_name=instana_cookie_name
         )
 
-        # Create API client
+        # Enrich tracking with x-mcp-user-id forwarded by the upstream coordinator.
+        # get_http_headers() returns all non-auth request headers, so this is safe.
+        if tracking is not None:
+            user_id = headers.get("x-mcp-user-id", "")
+            if user_id:
+                tracking["X-MCP-User-ID"] = user_id
+
+        # Create API client, stamping tracking headers onto it
         api_client_instance, error = _create_api_client_with_config(
-            instana_base_url, instana_api_token, instana_jwt_token, auth_headers
+            instana_base_url, instana_api_token, instana_jwt_token, auth_headers, tracking
         )
         if error:
             return error
@@ -432,9 +494,9 @@ def _auth_check_mock(allow_mock, kwargs):
     return False
 
 
-def _auth_try_http(api_class):
+def _auth_try_http(api_class, tracking: Optional[Dict[str, str]] = None):
     """Try HTTP mode authentication and return (api_instance, error)."""
-    api_instance = _try_http_mode_auth(api_class)
+    api_instance = _try_http_mode_auth(api_class, tracking)
     if isinstance(api_instance, dict) and "error" in api_instance:
         return None, api_instance
     return api_instance, None
@@ -462,8 +524,43 @@ async def _auth_wrapper_logic(func, self, args, kwargs, api_class, allow_mock):
     if _auth_check_mock(allow_mock, kwargs):
         return await func(self, *args, **kwargs)
 
-    # Try HTTP mode first
-    api_instance, error = _auth_try_http(api_class)
+    # Extract the FastMCP Context injected by FastMCP for tools that declare
+    # `ctx: Optional[Context]`. Used to read session_id, request_id, and clientInfo.
+    #
+    # ctx can arrive two ways:
+    #   1. As a keyword argument  → kwargs["ctx"]          (top-level router tools)
+    #   2. As a positional argument → args[n]              (internal helpers called as
+    #      `await self._method(id, ctx)` without an explicit keyword)
+    # We check kwargs first, then fall back to inspecting the function signature to
+    # locate the positional index of the `ctx` parameter.
+    ctx = kwargs.get("ctx")
+    if ctx is None:
+        import inspect as _inspect
+        try:
+            _param_names = list(_inspect.signature(func).parameters.keys())
+            # param_names[0] is always 'self'; args starts after self
+            _ctx_pos = _param_names.index("ctx") - 1  # -1 to skip 'self'
+            if 0 <= _ctx_pos < len(args):
+                ctx = args[_ctx_pos]
+        except (ValueError, TypeError):
+            pass  # 'ctx' not in signature or inspection failed — leave ctx as None
+
+    # Build per-call tracking context for the HTTP path.
+    # x-mcp-user-id is read later inside _try_http_mode_auth where we have the
+    # raw HTTP request headers from get_http_headers().
+    tracking = _build_mcp_tracking_context(ctx=ctx)
+
+    logger.info(
+        "MCP tool call | tool=%s session_id=%s request_id=%s client=%s user_id=%s",
+        func.__name__,
+        tracking.get("X-MCP-Session-ID", "-"),
+        tracking.get("X-MCP-Request-ID", "-"),
+        tracking.get("X-MCP-Client", "-"),
+        tracking.get("X-MCP-User-ID", "-"),
+    )
+
+    # Try HTTP mode first — passes tracking so headers are stamped on the ApiClient
+    api_instance, error = _auth_try_http(api_class, tracking)
     if error:
         return error
 
@@ -471,7 +568,7 @@ async def _auth_wrapper_logic(func, self, args, kwargs, api_class, allow_mock):
         kwargs['api_client'] = api_instance
         return await func(self, *args, **kwargs)
 
-    # Fall back to STDIO mode
+    # Fall back to STDIO mode (tracking not applied for POC scope)
     api_instance, error = _auth_try_stdio(self, api_class)
     if error:
         return error

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -170,13 +170,14 @@ class TestBaseInstanaClient(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures"""
+        # Patch SSL verify to False BEFORE constructing the client so that
+        # BaseInstanaClient.__init__ captures False in self.ssl_verify.
+        self._ssl_patch = patch('src.core.utils._ssl_verify_from_env', return_value=False)
+        self._ssl_patch.start()
         # Create the client
         self.read_token = "test_token"
         self.base_url = "https://test.instana.io"
         self.client = BaseInstanaClient(read_token=self.read_token, base_url=self.base_url)
-        # Patch SSL verify to False so tests reflect disabled-SSL behaviour
-        self._ssl_patch = patch('src.core.utils._ssl_verify_from_env', return_value=False)
-        self._ssl_patch.start()
 
     def tearDown(self):
         self._ssl_patch.stop()
@@ -1254,8 +1255,8 @@ class TestVersionImport(unittest.TestCase):
         # Re-import to trigger the version logic
         importlib.reload(src.core.utils)
 
-        # Check that the fallback version was used (updated to 1.0.0)
-        self.assertEqual(src.core.utils.__version__, "1.0.0")
+        # Check that the fallback version was used (updated to 0.9.6)
+        self.assertEqual(src.core.utils.__version__, "0.9.6")
 
     def test_version_used_in_headers(self):
         """Test that __version__ is used in User-Agent headers"""
@@ -1270,6 +1271,218 @@ class TestVersionImport(unittest.TestCase):
         self.assertIn("User-Agent", headers)
         self.assertIn(current_version, headers["User-Agent"])
         self.assertEqual(headers["User-Agent"], f"MCP-server/{current_version}")
+
+
+class TestMcpTrackingHelpers(unittest.TestCase):
+    """Tests for _get_ctx_session_id, _get_ctx_request_id, _get_ctx_client_name,
+    _build_mcp_tracking_context, _stamp_tracking_headers, and the ctx-extraction
+    logic inside _auth_wrapper_logic."""
+
+    # ------------------------------------------------------------------
+    # _get_ctx_session_id
+    # ------------------------------------------------------------------
+
+    def test_get_ctx_session_id_returns_value(self):
+        ctx = MagicMock()
+        ctx.session_id = "sess-abc"
+        from src.core.utils import _get_ctx_session_id
+        self.assertEqual(_get_ctx_session_id(ctx), "sess-abc")
+
+    def test_get_ctx_session_id_returns_none_when_empty(self):
+        ctx = MagicMock()
+        ctx.session_id = ""
+        from src.core.utils import _get_ctx_session_id
+        self.assertIsNone(_get_ctx_session_id(ctx))
+
+    def test_get_ctx_session_id_returns_none_on_exception(self):
+        ctx = MagicMock()
+        type(ctx).session_id = property(lambda self: (_ for _ in ()).throw(RuntimeError("no session")))
+        from src.core.utils import _get_ctx_session_id
+        self.assertIsNone(_get_ctx_session_id(ctx))
+
+    # ------------------------------------------------------------------
+    # _get_ctx_request_id
+    # ------------------------------------------------------------------
+
+    def test_get_ctx_request_id_returns_value(self):
+        ctx = MagicMock()
+        ctx.request_id = "7"
+        from src.core.utils import _get_ctx_request_id
+        self.assertEqual(_get_ctx_request_id(ctx), "7")
+
+    def test_get_ctx_request_id_returns_none_when_empty(self):
+        ctx = MagicMock()
+        ctx.request_id = ""
+        from src.core.utils import _get_ctx_request_id
+        self.assertIsNone(_get_ctx_request_id(ctx))
+
+    def test_get_ctx_request_id_returns_none_on_exception(self):
+        ctx = MagicMock()
+        type(ctx).request_id = property(lambda self: (_ for _ in ()).throw(RuntimeError("no request")))
+        from src.core.utils import _get_ctx_request_id
+        self.assertIsNone(_get_ctx_request_id(ctx))
+
+    # ------------------------------------------------------------------
+    # _get_ctx_client_name
+    # ------------------------------------------------------------------
+
+    def test_get_ctx_client_name_returns_value(self):
+        ctx = MagicMock()
+        ctx.session.client_params.clientInfo.name = "github.copilot"
+        from src.core.utils import _get_ctx_client_name
+        self.assertEqual(_get_ctx_client_name(ctx), "github.copilot")
+
+    def test_get_ctx_client_name_returns_none_when_no_session(self):
+        ctx = MagicMock()
+        ctx.session = None
+        from src.core.utils import _get_ctx_client_name
+        self.assertIsNone(_get_ctx_client_name(ctx))
+
+    def test_get_ctx_client_name_returns_none_on_exception(self):
+        ctx = MagicMock()
+        type(ctx).session = property(lambda self: (_ for _ in ()).throw(RuntimeError("no session")))
+        from src.core.utils import _get_ctx_client_name
+        self.assertIsNone(_get_ctx_client_name(ctx))
+
+    # ------------------------------------------------------------------
+    # _build_mcp_tracking_context
+    # ------------------------------------------------------------------
+
+    def test_build_tracking_returns_empty_dict_when_no_ctx(self):
+        from src.core.utils import _build_mcp_tracking_context
+        result = _build_mcp_tracking_context()
+        self.assertEqual(result, {})
+
+    def test_build_tracking_with_full_ctx(self):
+        ctx = MagicMock()
+        ctx.session_id = "sess-123"
+        ctx.request_id = "5"
+        ctx.session.client_params.clientInfo.name = "claude-desktop"
+        from src.core.utils import _build_mcp_tracking_context
+        result = _build_mcp_tracking_context(ctx=ctx)
+        self.assertEqual(result["X-MCP-Session-ID"], "sess-123")
+        self.assertEqual(result["X-MCP-Request-ID"], "5")
+        self.assertEqual(result["X-MCP-Client"], "claude-desktop")
+        self.assertNotIn("X-MCP-User-ID", result)
+
+    def test_build_tracking_with_http_user_id(self):
+        from src.core.utils import _build_mcp_tracking_context
+        result = _build_mcp_tracking_context(http_headers={"x-mcp-user-id": "jay@ibm.com"})
+        self.assertEqual(result["X-MCP-User-ID"], "jay@ibm.com")
+
+    def test_build_tracking_omits_empty_user_id(self):
+        from src.core.utils import _build_mcp_tracking_context
+        result = _build_mcp_tracking_context(http_headers={"x-mcp-user-id": ""})
+        self.assertNotIn("X-MCP-User-ID", result)
+
+    def test_build_tracking_omits_missing_ctx_fields(self):
+        """When ctx raises for session_id/request_id they are omitted, not set to None."""
+        ctx = MagicMock()
+        type(ctx).session_id = property(lambda self: (_ for _ in ()).throw(RuntimeError()))
+        type(ctx).request_id = property(lambda self: (_ for _ in ()).throw(RuntimeError()))
+        type(ctx).session = property(lambda self: (_ for _ in ()).throw(RuntimeError()))
+        from src.core.utils import _build_mcp_tracking_context
+        result = _build_mcp_tracking_context(ctx=ctx)
+        self.assertNotIn("X-MCP-Session-ID", result)
+        self.assertNotIn("X-MCP-Request-ID", result)
+        self.assertNotIn("X-MCP-Client", result)
+
+    # ------------------------------------------------------------------
+    # _stamp_tracking_headers
+    # ------------------------------------------------------------------
+
+    def test_stamp_tracking_headers_sets_all_non_empty(self):
+        from src.core.utils import _stamp_tracking_headers
+        mock_client = MagicMock()
+        tracking = {
+            "X-MCP-Session-ID": "sess-abc",
+            "X-MCP-Request-ID": "3",
+            "X-MCP-Client": "mcp-use",
+        }
+        _stamp_tracking_headers(mock_client, tracking)
+        mock_client.set_default_header.assert_any_call("X-MCP-Session-ID", "sess-abc")
+        mock_client.set_default_header.assert_any_call("X-MCP-Request-ID", "3")
+        mock_client.set_default_header.assert_any_call("X-MCP-Client", "mcp-use")
+        self.assertEqual(mock_client.set_default_header.call_count, 3)
+
+    def test_stamp_tracking_headers_skips_empty_values(self):
+        from src.core.utils import _stamp_tracking_headers
+        mock_client = MagicMock()
+        _stamp_tracking_headers(mock_client, {"X-MCP-Session-ID": "", "X-MCP-Client": "copilot"})
+        # Only the non-empty one should be set
+        mock_client.set_default_header.assert_called_once_with("X-MCP-Client", "copilot")
+
+    def test_stamp_tracking_headers_no_calls_for_empty_dict(self):
+        from src.core.utils import _stamp_tracking_headers
+        mock_client = MagicMock()
+        _stamp_tracking_headers(mock_client, {})
+        mock_client.set_default_header.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # ctx positional extraction in _auth_wrapper_logic
+    # ------------------------------------------------------------------
+
+    def test_auth_wrapper_extracts_ctx_from_kwargs(self):
+        """ctx passed as keyword argument is picked up correctly."""
+        with patch('fastmcp.server.dependencies.get_http_headers') as mock_headers, \
+             patch('instana_client.configuration.Configuration') as mock_cfg, \
+             patch('instana_client.api_client.ApiClient') as mock_api:
+
+            mock_headers.return_value = {
+                "instana-api-token": "tok",
+                "instana-base-url": "https://test.instana.io",
+            }
+            mock_cfg.return_value = MagicMock(api_key={}, api_key_prefix={})
+            mock_api.return_value = MagicMock()
+
+            ctx = MagicMock()
+            ctx.session_id = "kwarg-session"
+            ctx.request_id = "1"
+            ctx.session.client_params.clientInfo.name = "test-client"
+
+            class FakeApiClass:
+                def __init__(self, api_client):
+                    pass
+
+            @with_header_auth(FakeApiClass)
+            async def tool_method(self, ctx=None, api_client=None):
+                return {"ok": True}
+
+            client = BaseInstanaClient(read_token="tok", base_url="https://test.instana.io")
+            result = asyncio.run(tool_method(client, ctx=ctx))
+            self.assertEqual(result, {"ok": True})
+
+    def test_auth_wrapper_extracts_ctx_from_positional_args(self):
+        """ctx passed positionally (as internal helpers do) is still picked up."""
+        with patch('fastmcp.server.dependencies.get_http_headers') as mock_headers, \
+             patch('instana_client.configuration.Configuration') as mock_cfg, \
+             patch('instana_client.api_client.ApiClient') as mock_api:
+
+            mock_headers.return_value = {
+                "instana-api-token": "tok",
+                "instana-base-url": "https://test.instana.io",
+            }
+            mock_cfg.return_value = MagicMock(api_key={}, api_key_prefix={})
+            mock_api.return_value = MagicMock()
+
+            ctx = MagicMock()
+            ctx.session_id = "pos-session"
+            ctx.request_id = "2"
+            ctx.session.client_params.clientInfo.name = "test-client"
+
+            class FakeApiClass:
+                def __init__(self, api_client):
+                    pass
+
+            @with_header_auth(FakeApiClass)
+            async def internal_helper(self, some_id: str, ctx=None, api_client=None):
+                return {"ok": True}
+
+            client = BaseInstanaClient(read_token="tok", base_url="https://test.instana.io")
+            # Simulates: await self._internal_helper(id, ctx)  — ctx is positional
+            result = asyncio.run(internal_helper(client, "some-id", ctx))
+            self.assertEqual(result, {"ok": True})
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# feat: Add MCP call tracking headers for segmentation in HTTP mode

## Summary

Adds MCP call tracking headers to every outgoing Instana REST API request made in HTTP (streamable-HTTP) transport mode.

This enables the Instana backend to group, filter, and segment MCP-originated API calls by session, request sequence, and LLM client — without requiring any external coordinator.

## Problem

Previously, all MCP tool invocations hitting the Instana backend were indistinguishable from each other. The backend segmentation logs only showed:

```json
{"mcpVersion":"0.12.70","mcpMethod":"GET","mcpUserAgent":"MCP-server/0.12.70","mcpPath":"api/..."}
```

There was no way to tell which conversation, which tool call, or which LLM client triggered a given API request.

Additionally, when internal helper methods (e.g. `_get_application_config`) were called positionally rather than with keyword arguments, the `ctx` parameter was not being picked up by the `with_header_auth` decorator, resulting in all tracking fields logging as `-`.

## Changes

### `src/core/utils.py`

#### New: `_build_mcp_tracking_context(ctx, http_headers)`

Collects tracking signals from the FastMCP `Context` object and the live HTTP request headers.

All fields are opportunistic — missing values are silently omitted.

| Header | Source | Available without coordinator? |
| --- | --- | --- |
| `X-MCP-Session-ID` | `ctx.session_id` — the `mcp-session-id` the MCP client sends |  Yes: from MCP protocol |
| `X-MCP-Request-ID` | `ctx.request_id` — the JSON-RPC request ID |  Yes: from MCP protocol |
| `X-MCP-Client` | `ctx.session.client_params.clientInfo.name` — declared during `initialize` handshake |  Yes: from MCP protocol |
| `X-MCP-User-ID` | `x-mcp-user-id` HTTP header | Only if using session based auth |

#### New: `_stamp_tracking_headers(api_client_instance, tracking)`

Loops through the tracking dictionary and calls `set_default_header()` on the SDK `ApiClient` so every outgoing REST call in that invocation carries the same tracking headers.

#### Updated: `_create_api_client_with_config()`

Accepts an optional `tracking` dictionary and stamps it onto the `ApiClient` after auth headers.

#### Updated: `_try_http_mode_auth()`

Accepts `tracking`, reads `x-mcp-user-id` from the current request's HTTP headers via `get_http_headers()`, and passes tracking into `_create_api_client_with_config()`.

#### Updated: `_auth_try_http()`

Passes `tracking` through to `_try_http_mode_auth()`.

#### Updated: `_auth_wrapper_logic()`

- Extracts `ctx` from both `kwargs` and positional `args` using `inspect.signature`
- Fixes the case where internal helpers are called positionally, for example:

```python
await self._get_application_config(id, ctx)
```

- Builds the tracking context once per invocation
- Logs all tracking fields at `INFO` level
- Passes tracking to the HTTP auth path

## What the backend now sees per call

The MCP server logs the tracking context for each tool invocation:

```text
MCP tool call | tool=_get_application_config session_id=d3f440ab... request_id=6 client=mcp-use user_id=-
```

Every Instana REST request from that tool invocation carries:

```text
X-MCP-Session-ID: d3f440ab94c84e868c08138a98e9f5a4
X-MCP-Request-ID: 6
X-MCP-Client: mcp-use
```

If an upstream coordinator provides a user ID, the request will also carry:

```text
X-MCP-User-ID: <user-id>
```

## Tracking Flow

The tracking information flows from the MCP request context into the Instana REST API client:

```text
MCP Client
    |
    | MCP session / request / client information
    v
FastMCP Context
    |
    | ctx.session_id
    | ctx.request_id
    | ctx.session.client_params.clientInfo.name
    v
_auth_wrapper_logic()
    |
    | Build tracking context
    v
_try_http_mode_auth()
    |
    | Read optional x-mcp-user-id
    v
_create_api_client_with_config()
    |
    | Stamp tracking headers
    v
Instana SDK ApiClient
    |
    | X-MCP-Session-ID
    | X-MCP-Request-ID
    | X-MCP-Client
    | X-MCP-User-ID (if available)
    v
Instana REST API
```

## Example

For an MCP request with:

```text
Session ID: d3f440ab94c84e868c08138a98e9f5a4
Request ID: 6
Client: mcp-use
User ID: -
```

The MCP server logs:

```text
MCP tool call | tool=_get_application_config session_id=d3f440ab... request_id=6 client=mcp-use user_id=-
```

And the corresponding Instana REST API requests include:

```http
X-MCP-Session-ID: d3f440ab94c84e868c08138a98e9f5a4
X-MCP-Request-ID: 6
X-MCP-Client: mcp-use
```

This allows the Instana backend to associate multiple REST API calls with the same MCP session, individual MCP request, and originating MCP client.

## Why No External Coordinator Is Required

The following tracking information is already available through the MCP protocol:

- `ctx.session_id` provides the MCP session identifier
- `ctx.request_id` provides the JSON-RPC request identifier
- `ctx.session.client_params.clientInfo.name` provides the client name declared during the MCP `initialize` handshake

Therefore, these fields can be propagated directly from the MCP server to the Instana backend without requiring an additional coordinator or client-side configuration.

The user ID is different because it is not inherently provided by the MCP protocol. `X-MCP-User-ID` is therefore only available when an upstream coordinator or gateway explicitly forwards it.

## Scope

- **HTTP / streamable-HTTP mode only** — POC scope
- STDIO tracking is a follow-up
- No changes to tool signatures
- No changes to tool behaviour
- No changes to any public API
- Existing authentication behaviour remains unchanged when tracking information is unavailable

## Testing

All existing unit tests pass:

```text
84 passed
```