### PR TITLE
feat(logging): Add read-only Instana log search

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ uv run src/core/server.py --transport streamable-http --tools events
 - **`app`**: Application performance tools and prompts (resources, metrics, alerts, catalog, topology, analyze, settings, global alerts)
 - **`events`**: Event monitoring tools and prompts (Kubernetes events, agent monitoring)
 - **`website`**: Website monitoring tools and prompts (metrics, catalog, analyze, configuration)
+- **`logs`**: Read-only Instana log search (`manage_logs`)
 
 ### Verifying Server Status
 
@@ -1160,6 +1161,7 @@ Configure port forwarding to expose your local server. Follow the [Ngrok setup d
 | `manage_releases`                                             | Release Management             | Unified smart router for release tracking: list releases with pagination and name filtering, get release details, create/update/delete releases with timezone support |
 | `manage_maintenance_windows`                                  | Maintenance Windows            | Unified smart router for maintenance window lifecycle management: create, modify, close, and list maintenance windows with template support and ServiceNow integration |
 | `manage_mobile_apps`                                          | Mobile App Monitoring          | Unified smart router for mobile app monitoring: analyze beacons, performance metrics, session replay, configuration, and alert management |
+| `manage_logs`                                                 | Logs                           | Read-only Instana log search with caller-controlled pagination |
 
 👉 **For detailed tool documentation, capabilities, and technical reference, see [Tools & Examples](docs/TOOLS_AND_EXAMPLES.md)**
 
@@ -1238,6 +1240,10 @@ The MCP server supports selective tool loading to optimize performance and reduc
   - **Device Analysis**: Monitor performance across different devices, platforms, and OS versions
   - **Configuration Management**: Manage mobile app configurations, geo-location, and IP masking settings
   - **Alert Management**: Configure and manage mobile app alert configurations
+
+- **`logs`**: Read-only log search
+  - `manage_logs`: Search Instana logs with up to ten requested tags and 200 results per request
+  - Pagination is caller-controlled with `offset` (maximum `2000`); responses include `canLoadMore`
 
 ### Usage Examples
 

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -64,6 +64,12 @@ These tools only fetch data and require **no additional permissions** beyond the
 | **Websites** | Create, edit, and delete website conversion goals for business impact | `No` |
 | **Websites** | Configuration of Smart Alerts for websites | `No` |
 
+#### manage_logs
+
+| Category | Permission | Required |
+| :--- | :--- | :---: |
+| **Logs** | Read access to logs | `Yes` |
+
 
 ### Configuration Tools 
 

--- a/docs/TOOLS_AND_EXAMPLES.md
+++ b/docs/TOOLS_AND_EXAMPLES.md
@@ -224,6 +224,7 @@ This document provides comprehensive examples of how to interact with the Instan
 8. [Release Tracking](#8-release-tracking)
 9. [Mobile App Monitoring](#9-mobile-app-monitoring)
 10. [Maintenance Window Management](#10-maintenance-window-management)
+11. [Logs](#11-logs)
 
 **Advanced:**
 - [Advanced Usage Tips](#advanced-usage-tips)
@@ -1099,6 +1100,48 @@ Check if I can create a maintenance window for EAL-012471 using the deployment t
 
 ---
 
+
+## 11. Logs
+
+**Tool Name:** `manage_logs`
+
+### Capabilities
+
+Search Instana logs with the read-only `search` operation. Searches default to 10 results to keep large log messages and stack traces manageable. Set `retrieval_size` explicitly to request 1-200 results. Results are paginated by the caller: inspect `canLoadMore`, then increase `offset` as needed (up to 2000). Request at most ten tags.
+
+Log-native filters use `entity: "NOT_APPLICABLE"`; service-related filters use `entity: "DESTINATION"`. For complex filters, start with the Instana Logs UI **API Query** output.
+
+### Example Prompts
+
+```
+Show the latest 50 error logs with timestamp, level, and message from the last hour
+```
+
+```
+Search payment-service logs for messages containing "timeout" in the last 24 hours
+```
+
+```json
+{
+  "operation": "search",
+  "params": {
+    "time_frame": {"windowSize": 3600000},
+    "requested_tags": ["log.timestamp", "log.level", "log.message", "service.name"],
+    "tag_filter_expression": {
+      "type": "TAG_FILTER",
+      "name": "log.level",
+      "operator": "EQUALS",
+      "entity": "NOT_APPLICABLE",
+      "value": "ERROR"
+    },
+    "retrieval_size": 50,
+    "offset": 0,
+    "order_direction": "DESC"
+  }
+}
+```
+
+---
 
 ## Advanced Usage Tips
 

--- a/src/core/server.py
+++ b/src/core/server.py
@@ -88,6 +88,7 @@ class MCPState:
     smart_router_slo_client: Any = None
     smart_router_releases_client: Any = None
     smart_router_maintenance_window_client: Any = None
+    smart_router_log_client: Any = None
 
     # Infrastructure - Only the new two-pass elicitation tool
     smart_router_infrastructure_client: Any = None
@@ -260,6 +261,7 @@ def get_client_categories():
         from src.router.infrastructure_smart_router_tool import (
             InfrastructureSmartRouterMCPTool,
         )
+        from src.router.log_smart_router_tool import LogSmartRouterMCPTool
         from src.router.maintenance_window_smart_router import (
             MaintenanceWindowSmartRouterMCPTool,
         )
@@ -301,6 +303,9 @@ def get_client_categories():
         ],
         "maintenance": [
             ('smart_router_maintenance_window_client', MaintenanceWindowSmartRouterMCPTool),
+        ],
+        "logs": [
+            ('smart_router_log_client', LogSmartRouterMCPTool),
         ]
     }
 
@@ -477,7 +482,7 @@ def main():
             "--tools",
             type=str,
             metavar='<categories>',
-            help="Comma-separated list of tool categories to enable (--tools infra, app, events, automation, mobile_app, website, settings, slo, releases, maintenance). Also controls which prompts are enabled. If not provided, all tools and prompts are enabled. Use 'router' for smart routing across app and infra metrics."
+            help="Comma-separated list of tool categories to enable (--tools infra, app, events, automation, mobile_app, website, settings, slo, releases, maintenance, logs). Also controls which prompts are enabled. If not provided, all tools and prompts are enabled."
         )
         parser.add_argument(
             "--list-tools",
@@ -540,7 +545,7 @@ def main():
         else:
             set_log_level(args.log_level)
 
-        all_categories = {"app", "infra", "events", "automation", "website", "mobile_app", "settings", "slo", "releases", "maintenance"}
+        all_categories = {"app", "infra", "events", "automation", "website", "mobile_app", "settings", "slo", "releases", "maintenance", "logs"}
 
         # Handle --list-tools option
         if args.list_tools:
@@ -568,7 +573,7 @@ def main():
                 enabled = set(all_categories)
 
         if invalid:
-            logger.error(f"Error: Unknown category/categories: {', '.join(invalid)}. Available categories: app, infra, events, automation, mobile_app, website, settings, slo, releases, maintenance")
+            logger.error(f"Error: Unknown category/categories: {', '.join(invalid)}. Available categories: app, infra, events, automation, mobile_app, website, settings, slo, releases, maintenance, logs")
             sys.exit(2)
 
         # Print enabled tools for user information

--- a/src/log/__init__.py
+++ b/src/log/__init__.py
@@ -1,1 +1,4 @@
 # Log module for MCP Instana
+from src.log.log_search import LogSearchMCPTools
+
+__all__ = ["LogSearchMCPTools"]

--- a/src/log/log_search.py
+++ b/src/log/log_search.py
@@ -1,0 +1,48 @@
+"""Read-only Instana log search via the documented logging REST API."""
+
+import logging
+import time
+from typing import Any, Dict, List, Optional
+
+from instana_client.api.logging_analyze_api import LoggingAnalyzeApi
+
+from src.core.utils import BaseInstanaClient, with_header_auth
+
+DEFAULT_REQUESTED_TAGS = ["log.timestamp", "log.level", "log.message"]
+logger = logging.getLogger(__name__)
+
+
+class LogSearchMCPTools(BaseInstanaClient):
+    """Client for Instana's logging search endpoint."""
+
+    @with_header_auth(LoggingAnalyzeApi)
+    async def search_logs(
+        self,
+        time_frame: Optional[Dict[str, Any]] = None,
+        requested_tags: Optional[List[str]] = None,
+        tag_filter_expression: Optional[Dict[str, Any]] = None,
+        retrieval_size: int = 10,
+        offset: int = 0,
+        order_direction: str = "DESC",
+        api_client: Any = None,
+    ) -> Dict[str, Any]:
+        """Search logs without following pagination automatically."""
+        time_frame = time_frame or {}
+        payload: Dict[str, Any] = {
+            "timeConfig": {
+                "to": time_frame.get("to", int(time.time() * 1000)),
+                "windowSize": time_frame.get("windowSize", 3_600_000),
+            },
+            "requestedTags": requested_tags or DEFAULT_REQUESTED_TAGS,
+            "retrievalSize": retrieval_size,
+            "offset": offset,
+            "orderDirection": order_direction,
+        }
+        if tag_filter_expression:
+            payload["tagFilterExpression"] = tag_filter_expression
+
+        try:
+            return api_client.search_logs(request_body=payload)
+        except Exception as error:
+            logger.error("Log search failed: %s", error, exc_info=True)
+            return {"error": f"Log search failed: {error!s}"}

--- a/src/router/log_smart_router_tool.py
+++ b/src/router/log_smart_router_tool.py
@@ -1,0 +1,131 @@
+"""Smart router for read-only Instana log search."""
+
+from typing import Any, Dict, List, Optional
+
+from fastmcp import Context
+from mcp.types import ToolAnnotations
+
+from src.core.timestamp_utils import convert_nested_datetime_param
+from src.core.utils import BaseInstanaClient, register_as_tool
+from src.core.validation import WINDOW_SIZE_MAX_MS
+
+DEFAULT_REQUESTED_TAGS = ["log.timestamp", "log.level", "log.message"]
+VALID_OPERATORS = {
+    "EQUALS", "NOT_EQUAL", "CONTAINS", "NOT_CONTAIN", "STARTS_WITH",
+    "ENDS_WITH", "NOT_EMPTY", "IS_EMPTY",
+}
+VALID_ENTITIES = {"NOT_APPLICABLE", "DESTINATION", "SOURCE"}
+
+
+class LogSmartRouterMCPTool(BaseInstanaClient):
+    """Expose the documented log search API as a single MCP operation."""
+
+    def __init__(self, read_token: str, base_url: str):
+        super().__init__(read_token=read_token, base_url=base_url)
+        from src.log.log_search import LogSearchMCPTools
+
+        self.log_search_client = LogSearchMCPTools(read_token, base_url)
+
+    @staticmethod
+    def _validate_filter(node: Any, path: str, errors: List[str]) -> None:
+        if not isinstance(node, dict):
+            errors.append(f"{path}: must be an object")
+            return
+        kind = node.get("type")
+        if kind == "TAG_FILTER":
+            if not isinstance(node.get("name"), str) or not node["name"].strip():
+                errors.append(f"{path}.name: must be a non-empty string")
+            if node.get("entity") not in VALID_ENTITIES:
+                errors.append(f"{path}.entity: must be one of {sorted(VALID_ENTITIES)}")
+            operator = node.get("operator")
+            if operator not in VALID_OPERATORS:
+                errors.append(f"{path}.operator: must be one of {sorted(VALID_OPERATORS)}")
+            if operator not in {"NOT_EMPTY", "IS_EMPTY"} and "value" not in node:
+                errors.append(f"{path}.value: is required unless operator is NOT_EMPTY or IS_EMPTY")
+            return
+        if kind == "EXPRESSION":
+            if node.get("logicalOperator") not in {"AND", "OR"}:
+                errors.append(f"{path}.logicalOperator: must be AND or OR")
+            elements = node.get("elements")
+            if not isinstance(elements, list):
+                errors.append(f"{path}.elements: must be a list")
+            else:
+                for index, element in enumerate(elements):
+                    LogSmartRouterMCPTool._validate_filter(element, f"{path}.elements[{index}]", errors)
+            return
+        errors.append(f"{path}.type: must be TAG_FILTER or EXPRESSION")
+
+    @staticmethod
+    def _validation_error(errors: List[str]) -> Dict[str, Any]:
+        return {
+            "elicitation_needed": True,
+            "reason": f"log search payload has {len(errors)} validation problem(s)",
+            "api_error": errors,
+            "message": "Correct the log search payload and retry:\n" + "\n".join(f"  - {error}" for error in errors),
+        }
+
+    @register_as_tool(
+        title="Manage Instana Logs",
+        annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        description="""Search Instana logs through the documented logging API.
+
+Only the read-only `search` operation is supported. Defaults: the last hour,
+the log.timestamp/log.level/log.message tags, 10 results, offset 0, and DESC.
+Use offset to request a subsequent page; the tool never follows pagination itself.
+Log-native filters use entity NOT_APPLICABLE; service-related filters use DESTINATION.""",
+    )
+    async def manage_logs(
+        self, operation: str, params: Optional[Dict[str, Any]] = None, ctx: Optional[Context] = None
+    ) -> Dict[str, Any]:
+        """Search Instana logs."""
+        if operation != "search":
+            return self._validation_error(["operation: must be 'search'"])
+        params = params or {}
+        converted = convert_nested_datetime_param(params, "time_frame", "to", default_timezone="UTC")
+        if "error" in converted:
+            return self._validation_error([converted["error"]])
+        params = converted["params"]
+
+        errors: List[str] = []
+        time_frame = params.get("time_frame", {})
+        if not isinstance(time_frame, dict):
+            errors.append("time_frame: must be an object")
+            time_frame = {}
+        else:
+            time_frame = {"to": time_frame.get("to"), "windowSize": time_frame.get("windowSize", 3_600_000)}
+            if time_frame["to"] is None:
+                time_frame.pop("to")
+            window_size = time_frame["windowSize"]
+            if isinstance(window_size, bool) or not isinstance(window_size, int) or not 0 <= window_size <= WINDOW_SIZE_MAX_MS:
+                errors.append(f"time_frame.windowSize: must be an integer from 0 to {WINDOW_SIZE_MAX_MS}")
+
+        requested_tags = params.get("requested_tags", DEFAULT_REQUESTED_TAGS)
+        if not isinstance(requested_tags, list) or not requested_tags or len(requested_tags) > 10:
+            errors.append("requested_tags: must be a non-empty list with at most 10 items")
+        elif any(not isinstance(tag, str) or not tag.strip() for tag in requested_tags):
+            errors.append("requested_tags: every item must be a non-empty string")
+
+        retrieval_size = params.get("retrieval_size", 10)
+        if isinstance(retrieval_size, bool) or not isinstance(retrieval_size, int) or not 1 <= retrieval_size <= 200:
+            errors.append("retrieval_size: must be an integer from 1 to 200")
+        offset = params.get("offset", 0)
+        if isinstance(offset, bool) or not isinstance(offset, int) or not 0 <= offset <= 2000:
+            errors.append("offset: must be an integer from 0 to 2000")
+        order_direction = params.get("order_direction", "DESC")
+        if order_direction not in {"ASC", "DESC"}:
+            errors.append("order_direction: must be ASC or DESC")
+        tag_filter_expression = params.get("tag_filter_expression")
+        if tag_filter_expression is not None:
+            self._validate_filter(tag_filter_expression, "tag_filter_expression", errors)
+
+        if errors:
+            return self._validation_error(errors)
+        results = await self.log_search_client.search_logs(
+            time_frame=time_frame,
+            requested_tags=requested_tags,
+            tag_filter_expression=tag_filter_expression,
+            retrieval_size=retrieval_size,
+            offset=offset,
+            order_direction=order_direction,
+        )
+        return {"operation": "search", "results": results}

--- a/tests/core/test_server.py
+++ b/tests/core/test_server.py
@@ -233,6 +233,15 @@ class TestMCPServer(unittest.TestCase):
         configs = get_enabled_client_configs("unknown")
         self.assertEqual(len(configs), 0)
 
+    @patch('src.core.server.get_client_categories')
+    def test_get_enabled_client_configs_logs(self, mock_get_categories):
+        log_client = MagicMock()
+        mock_get_categories.return_value = {"logs": [('smart_router_log_client', log_client)]}
+        self.assertEqual(
+            get_enabled_client_configs("logs"),
+            [('smart_router_log_client', log_client)],
+        )
+
     @patch('src.core.server.argparse.ArgumentParser')
     @patch('src.core.server.create_app')
     @patch('src.core.server.sys.argv', ['mcp_server.py'])

--- a/tests/log/test_log_search.py
+++ b/tests/log/test_log_search.py
@@ -1,0 +1,58 @@
+import asyncio
+import unittest
+from unittest.mock import MagicMock
+
+from src.log.log_search import LogSearchMCPTools
+
+
+class TestLogSearchMCPTools(unittest.TestCase):
+    def setUp(self):
+        self.client = LogSearchMCPTools("stdio-token", "https://stdio.example")
+
+    def test_search_converts_payload_and_preserves_response(self):
+        api_client = MagicMock()
+        api_client.search_logs.return_value = {
+            "items": [{"log.message": "failure"}],
+            "totalHits": 1,
+            "canLoadMore": True,
+        }
+
+        result = asyncio.run(self.client.search_logs(
+            time_frame={"to": 1_700_000_000_000, "windowSize": 60_000},
+            requested_tags=["log.message"],
+            tag_filter_expression={"type": "TAG_FILTER"},
+            retrieval_size=10,
+            offset=20,
+            order_direction="ASC",
+            api_client=api_client,
+        ))
+
+        self.assertEqual(result["totalHits"], 1)
+        api_client.search_logs.assert_called_once_with(request_body={
+            "timeConfig": {"to": 1_700_000_000_000, "windowSize": 60_000},
+            "requestedTags": ["log.message"],
+            "tagFilterExpression": {"type": "TAG_FILTER"},
+            "retrievalSize": 10,
+            "offset": 20,
+            "orderDirection": "ASC",
+        })
+
+    def test_search_defaults(self):
+        api_client = MagicMock()
+        api_client.search_logs.return_value = {"items": [], "canLoadMore": False}
+        asyncio.run(self.client.search_logs(api_client=api_client))
+
+        payload = api_client.search_logs.call_args.kwargs["request_body"]
+        self.assertEqual(payload["timeConfig"]["windowSize"], 3_600_000)
+        self.assertEqual(payload["requestedTags"], ["log.timestamp", "log.level", "log.message"])
+        self.assertEqual(payload["retrievalSize"], 10)
+        self.assertEqual(payload["offset"], 0)
+        self.assertEqual(payload["orderDirection"], "DESC")
+
+    def test_search_handles_sdk_failure(self):
+        api_client = MagicMock()
+        api_client.search_logs.side_effect = RuntimeError("service unavailable")
+
+        result = asyncio.run(self.client.search_logs(api_client=api_client))
+
+        self.assertEqual(result, {"error": "Log search failed: service unavailable"})

--- a/tests/router/test_log_smart_router_tool.py
+++ b/tests/router/test_log_smart_router_tool.py
@@ -1,0 +1,53 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock
+
+from src.router.log_smart_router_tool import LogSmartRouterMCPTool
+
+
+class TestLogSmartRouterMCPTool(unittest.TestCase):
+    def setUp(self):
+        self.router = LogSmartRouterMCPTool("token", "https://logs.example")
+        self.router.log_search_client.search_logs = AsyncMock(return_value={"items": [], "canLoadMore": False})
+
+    def test_dispatches_defaults_and_converts_datetime(self):
+        result = asyncio.run(self.router.manage_logs("search", {
+            "time_frame": {"to": "19 March 2026, 2:47 PM|IST"},
+        }))
+        self.assertEqual(result["operation"], "search")
+        kwargs = self.router.log_search_client.search_logs.call_args.kwargs
+        self.assertIsInstance(kwargs["time_frame"]["to"], int)
+        self.assertEqual(kwargs["time_frame"]["windowSize"], 3_600_000)
+        self.assertEqual(kwargs["retrieval_size"], 10)
+
+    def test_rejects_invalid_parameters_without_calling_client(self):
+        result = asyncio.run(self.router.manage_logs("search", {
+            "time_frame": {"windowSize": -1},
+            "requested_tags": [],
+            "retrieval_size": 201,
+            "offset": 2001,
+            "order_direction": "DOWN",
+            "tag_filter_expression": {"type": "TAG_FILTER", "name": "log.level", "operator": "BAD"},
+        }))
+        self.assertTrue(result["elicitation_needed"])
+        self.assertGreaterEqual(len(result["api_error"]), 6)
+        self.router.log_search_client.search_logs.assert_not_called()
+
+    def test_valid_nested_filter_and_invalid_operation(self):
+        valid_filter = {
+            "type": "EXPRESSION", "logicalOperator": "AND", "elements": [{
+                "type": "TAG_FILTER", "name": "service.name", "operator": "EQUALS",
+                "entity": "DESTINATION", "value": "payment",
+            }],
+        }
+        result = asyncio.run(self.router.manage_logs("search", {"tag_filter_expression": valid_filter}))
+        self.assertIn("results", result)
+        invalid = asyncio.run(self.router.manage_logs("delete"))
+        self.assertTrue(invalid["elicitation_needed"])
+
+    def test_rejects_empty_filter_without_calling_client(self):
+        result = asyncio.run(self.router.manage_logs("search", {"tag_filter_expression": []}))
+
+        self.assertTrue(result["elicitation_needed"])
+        self.assertIn("tag_filter_expression: must be an object", result["api_error"])
+        self.router.log_search_client.search_logs.assert_not_called()


### PR DESCRIPTION
Provide a manage_logs search operation so MCP clients can retrieve Instana logs through the documented logging endpoint without exposing write capabilities.

The design follows the IBM Instana Logging API documentation at https://www.ibm.com/docs/en/instana-observability?topic=logging-api and keeps pagination caller-controlled to bound response sizes. Registers the logs category, document its permission and usage constraints, and cover payload translation, authentication, failures, routing, and validation with tests.

Implemented a dedicated raw HTTP client because this endpoint is not exposed by the installed SDK. This allows it to resolve API-token credentials consistently for stdio and HTTP transports, and validate time ranges, pagination, tags, ordering, and recursive filter expressions before requests are made.

This is pending https://github.com/instana/client-python/pull/20