### PR TITLE
fix: include custom-event meta in beacon summaries (website + mobile analyze)

### DIFF
--- a/src/mobile_app/mobile_app_analyze.py
+++ b/src/mobile_app/mobile_app_analyze.py
@@ -912,6 +912,9 @@ class MobileAppAnalyzeMCPTools(BaseInstanaClient):
             "rooted", "viewportWidth", "viewportHeight",
             # Trace correlation
             "backendTraceId", "parentBeaconId",
+            # Custom event metadata (user-defined key/value pairs — primary
+            # payload of CUSTOM beacons)
+            "meta",
             # Other
             "batchSize", "bytesIngested", "agentVersion"
         ]

--- a/src/website/website_analyze.py
+++ b/src/website/website_analyze.py
@@ -508,6 +508,10 @@ class WebsiteAnalyzeMCPTools(BaseInstanaClient):
             "stackTrace", "parsedStackTrace", "errorId", "stackTraceReadability",
             # Session and user tracking (all beacon types)
             "sessionId",
+            # Custom event metadata (user-defined key/value pairs, e.g. reported
+            # via ineum('reportEvent', name, {meta: {...}}) — primary payload of
+            # CUSTOM beacons)
+            "meta",
             # Backend correlation (for PAGELOAD beacons)
             "backendTraceId",
             # HTTP metrics (if applicable)

--- a/tests/mobile_app/test_mobile_app_analyze.py
+++ b/tests/mobile_app/test_mobile_app_analyze.py
@@ -177,6 +177,27 @@ class TestMobileAppAnalyzeMCPTools(unittest.IsolatedAsyncioTestCase):
     def test_summarize_beacons_non_dict(self):
         self.assertEqual(self.client._summarize_beacons_response(["x"]), ["x"])
 
+    def test_summarize_includes_custom_event_meta(self):
+        input_data = {
+            "totalHits": 1,
+            "items": [
+                {
+                    "beacon": {
+                        "mobileAppLabel": "App1",
+                        "timestamp": 12345,
+                        "type": "custom",
+                        "meta": {"flow": "onboarding", "step": "signup"},
+                    }
+                }
+            ],
+        }
+        result = self.client._summarize_beacons_response(input_data)
+        self.assertEqual(len(result["beacons"]), 1)
+        self.assertEqual(
+            result["beacons"][0]["meta"],
+            {"flow": "onboarding", "step": "signup"},
+        )
+
     async def test_get_all_mobile_app_beacons_success(self):
         payload = {
             "totalHits": 1,

--- a/tests/website/test_website_analyze.py
+++ b/tests/website/test_website_analyze.py
@@ -459,6 +459,51 @@ class TestWebsiteAnalyzeMCPTools(unittest.TestCase):
         self.assertEqual(len(result["beacons"]), 1)
         self.assertEqual(result["beacons"][0]["websiteLabel"], "Test Site")
 
+    def test_summarize_includes_custom_event_meta(self):
+        """Custom-event meta key/value pairs must survive summarization"""
+        response_data = {
+            "totalHits": 1,
+            "items": [
+                {
+                    "beacon": {
+                        "beaconId": "abc123",
+                        "timestamp": 1234567890,
+                        "duration": 42,
+                        "type": "custom",
+                        "meta": {"flow": "checkout", "step": "payment", "attempt": "1"}
+                    }
+                }
+            ]
+        }
+
+        result = self.tools_instance._summarize_beacons_response(response_data)
+
+        self.assertEqual(len(result["beacons"]), 1)
+        self.assertEqual(
+            result["beacons"][0]["meta"],
+            {"flow": "checkout", "step": "payment", "attempt": "1"}
+        )
+
+    def test_summarize_skips_empty_meta(self):
+        """Beacons without meta (empty dict) should not carry an empty meta key"""
+        response_data = {
+            "totalHits": 1,
+            "items": [
+                {
+                    "beacon": {
+                        "beaconId": "abc123",
+                        "timestamp": 1234567890,
+                        "meta": {}
+                    }
+                }
+            ]
+        }
+
+        result = self.tools_instance._summarize_beacons_response(response_data)
+
+        self.assertEqual(len(result["beacons"]), 1)
+        self.assertNotIn("meta", result["beacons"][0])
+
     def test_check_elicitation_all_params_missing(self):
         """Test elicitation when all parameters are missing"""
         result = self.tools_instance._check_elicitation_for_beacon_groups(None, None, None)


### PR DESCRIPTION
## Problem

`get_website_beacons` and `get_all_mobile_app_beacons` summarize each beacon through an `essential_fields` whitelist that omits `meta`. For `CUSTOM` beacons, the user-defined `meta` key/value pairs **are** the payload — they're what `ineum('reportEvent', name, {meta: {...}})` reports, and what the Instana UI shows in the beacon detail panel. The tag catalog also exposes `beacon.meta` / `mobileBeacon.meta` for filtering and grouping, yet the values are unreachable in list output: every custom-event beacon comes back with browser/OS/geo context but without the data the event was created to carry.

## Repro

1. Report a custom event with meta from any monitored website: `ineum('reportEvent', 'my_event', {meta: {flow: 'checkout', step: 'payment'}})`
2. Call `get_website_beacons` with `beacon_type: "CUSTOM"` filtered to that event.
3. The returned beacon objects contain no `meta` key, even though the raw `/api/website-monitoring/analyze/beacons` response includes it — `_summarize_beacons_response` drops it via the whitelist.

## Fix

Add `"meta"` to the summarizers' field whitelists in both the website and mobile-app analyze modules. The existing empty-value skip logic already removes empty `meta` dicts, so beacons without meta are byte-identical to before and the summarizer's size-reduction purpose (the ~70-80% cut noted in its docstring) is preserved for non-custom beacon types.

## Tests

- `tests/website/test_website_analyze.py`: meta survives summarization; empty meta stays omitted.
- `tests/mobile_app/test_mobile_app_analyze.py`: meta survives summarization.

`uv run test` passes (the only failure, `TestVersionImport.test_version_fallback_on_exception`, is pre-existing on `main` — it asserts a hardcoded `0.9.6` fallback against the current `1.0.0`). `uv run ruff check .` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)