### PR TITLE
fix: pass groupbyTagSecondLevelKey through beacon-group mapping (website + mobile analyze)

### DIFF
--- a/src/mobile_app/mobile_app_analyze.py
+++ b/src/mobile_app/mobile_app_analyze.py
@@ -115,6 +115,14 @@ class MobileAppAnalyzeMCPTools(BaseInstanaClient):
             "groupbyTag": group.get("groupbyTag") or group.get("groupByTag", DEFAULT_GROUP_BY_TAG),
             "groupbyTagEntity": group.get("groupbyTagEntity") or group.get("groupByTagEntity", DEFAULT_GROUP_BY_TAG_ENTITY),
         }
+        # Optional 2nd-level key for key/value tags (e.g. the sub-key of
+        # mobileBeacon.meta) — supported by the API's MobileAppBeaconTagGroup model
+        second_level_key = (
+            group.get("groupbyTagSecondLevelKey")
+            or group.get("groupByTagSecondLevelKey")
+        )
+        if second_level_key:
+            mapped_group["groupbyTagSecondLevelKey"] = second_level_key
         query_params["group"] = mapped_group
 
         # Convert tag filter expression to SDK model
@@ -273,16 +281,19 @@ class MobileAppAnalyzeMCPTools(BaseInstanaClient):
 
                 {
                     "groupbyTag": "<tag_name>",
-                    "groupbyTagEntity": "<entity_type>"
+                    "groupbyTagEntity": "<entity_type>",
+                    "groupbyTagSecondLevelKey": "<optional sub-key for key/value tags>"
                 }
 
                 Rules:
-                - Only `groupbyTag` and `groupbyTagEntity` keys are supported.
+                - Only `groupbyTag`, `groupbyTagEntity` and `groupbyTagSecondLevelKey` keys are supported.
                 - camelCase variants such as `groupByTag` are NOT supported.
                 - If `group` is not provided, default grouping will be applied.
                 - If `group` is provided but fields are missing:
                     - groupbyTag defaults to: mobileBeacon.mobileApp.name
                     - groupbyTagEntity defaults to: NOT_APPLICABLE
+                - `groupbyTagSecondLevelKey` is optional; use it to group a
+                  key/value tag (e.g. `mobileBeacon.meta`) by one of its keys.
             tag_filter_expression: Filter expression for tags
                 Example: {
                     "type": "TAG_FILTER",

--- a/src/website/website_analyze.py
+++ b/src/website/website_analyze.py
@@ -153,6 +153,15 @@ class WebsiteAnalyzeMCPTools(BaseInstanaClient):
         elif "groupbyTagEntity" in group:
             mapped_group["groupbyTagEntity"] = group["groupbyTagEntity"]
 
+        # Optional 2nd-level key for key/value tags (e.g. the sub-key of
+        # beacon.meta) — supported by the API's WebsiteBeaconTagGroup model
+        second_level_key = (
+            group.get("groupByTagSecondLevelKey")
+            or group.get("groupbyTagSecondLevelKey")
+        )
+        if second_level_key:
+            mapped_group["groupbyTagSecondLevelKey"] = second_level_key
+
         mapped_group.setdefault("groupbyTag", DEFAULT_GROUP_BY_TAG)
         mapped_group.setdefault("groupbyTagEntity", DEFAULT_GROUP_BY_TAG_ENTITY)
         return mapped_group
@@ -289,6 +298,10 @@ class WebsiteAnalyzeMCPTools(BaseInstanaClient):
                 ]
             group: Grouping configuration
                 Example: {"groupByTag": "beacon.page.name"}
+                For key/value tags (e.g. `beacon.meta`), an optional
+                `groupbyTagSecondLevelKey` selects the sub-key to group by:
+                {"groupbyTag": "beacon.meta", "groupbyTagEntity": "NOT_APPLICABLE",
+                 "groupbyTagSecondLevelKey": "myKey"}
             tag_filter_expression: Filter expression for tags
                 Example: {
                     "type": "TAG_FILTER",

--- a/tests/mobile_app/test_mobile_app_analyze.py
+++ b/tests/mobile_app/test_mobile_app_analyze.py
@@ -177,6 +177,34 @@ class TestMobileAppAnalyzeMCPTools(unittest.IsolatedAsyncioTestCase):
     def test_summarize_beacons_non_dict(self):
         self.assertEqual(self.client._summarize_beacons_response(["x"]), ["x"])
 
+    def test_build_beacon_groups_query_params_passes_second_level_key(self):
+        query_params = self.client._build_beacon_groups_query_params(
+            beacon_type="CUSTOM_EVENT",
+            metrics=[{"metric": "beaconCount", "aggregation": "SUM"}],
+            group={
+                "groupbyTag": "mobileBeacon.meta",
+                "groupbyTagEntity": "NOT_APPLICABLE",
+                "groupbyTagSecondLevelKey": "myKey",
+            },
+            time_frame={"windowSize": 3600000},
+            tag_filter_expression=None,
+            order=None,
+            pagination=None,
+        )
+        self.assertEqual(query_params["group"]["groupbyTagSecondLevelKey"], "myKey")
+
+    def test_build_beacon_groups_query_params_omits_absent_second_level_key(self):
+        query_params = self.client._build_beacon_groups_query_params(
+            beacon_type="CUSTOM_EVENT",
+            metrics=[{"metric": "beaconCount", "aggregation": "SUM"}],
+            group={"groupbyTag": "mobileBeacon.mobileApp.name"},
+            time_frame={"windowSize": 3600000},
+            tag_filter_expression=None,
+            order=None,
+            pagination=None,
+        )
+        self.assertNotIn("groupbyTagSecondLevelKey", query_params["group"])
+
     async def test_get_all_mobile_app_beacons_success(self):
         payload = {
             "totalHits": 1,

--- a/tests/website/test_website_analyze.py
+++ b/tests/website/test_website_analyze.py
@@ -278,6 +278,31 @@ class TestWebsiteAnalyzeMCPTools(unittest.TestCase):
         self.assertEqual(self.tools_instance.read_token, "test_token")
         self.assertEqual(self.tools_instance.base_url, "https://test.instana.io")
 
+    def test_map_group_fields_passes_second_level_key(self):
+        """groupbyTagSecondLevelKey must survive group field mapping"""
+        mapped = self.tools_instance._map_group_fields({
+            "groupbyTag": "beacon.meta",
+            "groupbyTagEntity": "NOT_APPLICABLE",
+            "groupbyTagSecondLevelKey": "myKey"
+        })
+        self.assertEqual(mapped["groupbyTagSecondLevelKey"], "myKey")
+        self.assertEqual(mapped["groupbyTag"], "beacon.meta")
+
+    def test_map_group_fields_second_level_key_camel_case(self):
+        """camelCase groupByTagSecondLevelKey is accepted like the other group fields"""
+        mapped = self.tools_instance._map_group_fields({
+            "groupByTag": "beacon.meta",
+            "groupByTagSecondLevelKey": "myKey"
+        })
+        self.assertEqual(mapped["groupbyTagSecondLevelKey"], "myKey")
+
+    def test_map_group_fields_omits_absent_second_level_key(self):
+        """No groupbyTagSecondLevelKey in the output when not provided"""
+        mapped = self.tools_instance._map_group_fields({
+            "groupbyTag": "beacon.page.name"
+        })
+        self.assertNotIn("groupbyTagSecondLevelKey", mapped)
+
     @PATCH_CATALOG
     def test_get_beacon_groups_with_all_params(self, _mock_catalog):
         """Test get_website_beacon_groups with all parameters"""


### PR DESCRIPTION
## Problem

`get_website_beacon_groups` and `get_mobile_app_beacon_groups` rebuild the caller's `group` object keeping only `groupbyTag` and `groupbyTagEntity` — `groupbyTagSecondLevelKey` is silently dropped (website: `_map_group_fields`; mobile: the inline mapping in `_build_beacon_groups_query_params`). That makes it impossible to group key/value tags (e.g. `beacon.meta` / `mobileBeacon.meta`) by a specific sub-key: the API then falls back to enumerating the map's key *names* instead of splitting by the requested key's *values*, with no error or warning to the caller.

## Repro

1. Report a custom event with meta from any monitored website, e.g. `ineum('reportEvent', 'my_event', {meta: {flow: 'checkout'}})`
2. Call `get_website_beacon_groups` with `group: {"groupbyTag": "beacon.meta", "groupbyTagEntity": "NOT_APPLICABLE", "groupbyTagSecondLevelKey": "flow"}`
3. Expected: groups split by the values of `flow` (`checkout`, …). Actual: a list of the meta key names — identical to omitting `groupbyTagSecondLevelKey` entirely.

## Fix

The API models already support the field — both `WebsiteBeaconTagGroup` and `MobileAppBeaconTagGroup` declare `groupbyTagSecondLevelKey` — so this change only forwards it: map the field in both modules (with the same camelCase-variant handling as the existing group fields) and document it in the tool docstrings.

## Tests

- website: sub-key passes through mapping; camelCase variant accepted; absent key stays absent.
- mobile: sub-key passes through the query-params builder; absent key stays absent.

`uv run test` passes (the only failure, `TestVersionImport.test_version_fallback_on_exception`, is pre-existing on `main`). `uv run ruff check .` passes.

Companion to #125 — together they make custom-event `meta` fully usable through the beacon analyze tools (values in list output, and grouping by sub-key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)