### PR TITLE
fix: reject unsupported beacon tag filters loudly instead of silently altering the query

### DIFF
--- a/src/mobile_app/mobile_app_analyze.py
+++ b/src/mobile_app/mobile_app_analyze.py
@@ -466,9 +466,24 @@ class MobileAppAnalyzeMCPTools(BaseInstanaClient):
 
         return pagination
 
+    # The beacons list endpoint only accepts the API's deprecated `tagFilters`
+    # format: a flat, implicitly AND-combined list of TAG_FILTERs without a
+    # `key` field. Anything richer must be rejected loudly — silently dropping
+    # `key`, OR semantics or nested expressions would change the query meaning
+    # without any signal to the caller.
+    _UNSUPPORTED_FILTER_HINT = (
+        "The beacons list endpoint only supports a single TAG_FILTER or a flat, "
+        "AND-combined EXPRESSION of TAG_FILTERs, without a 'key' field. For "
+        "filters that need 'key' (e.g. mobileBeacon.meta sub-keys), OR, or "
+        "nested expressions, use get_mobile_app_beacon_groups instead."
+    )
+
     def _convert_single_tag_filter(self, tag_filter: Dict[str, Any]) -> Union[Any, Dict[str, Any]]:
         """Convert a single TAG_FILTER to DeprecatedTagFilter."""
         from instana_client.models.deprecated_tag_filter import DeprecatedTagFilter
+
+        if tag_filter.get("key"):
+            return {"error": f"TAG_FILTER with a 'key' field is not supported here. {self._UNSUPPORTED_FILTER_HINT}"}
 
         name = tag_filter.get("name")
         operator = tag_filter.get("operator")
@@ -483,21 +498,16 @@ class MobileAppAnalyzeMCPTools(BaseInstanaClient):
 
         return DeprecatedTagFilter(**tag_filter_dict)
 
-    def _convert_expression_filters(self, elements: List[Dict[str, Any]]) -> List[Any]:
-        """Convert EXPRESSION elements to list of DeprecatedTagFilter."""
-        from instana_client.models.deprecated_tag_filter import DeprecatedTagFilter
-
+    def _convert_expression_filters(self, elements: List[Dict[str, Any]]) -> Union[List[Any], Dict[str, Any]]:
+        """Convert EXPRESSION elements to a list of DeprecatedTagFilter, or an error dict."""
         tag_filters = []
         for elem in elements:
-            if elem.get("type") == "TAG_FILTER":
-                tag_filter_dict = {
-                    "name": elem.get("name"),
-                    "operator": elem.get("operator"),
-                    "value": elem.get("value"),
-                }
-                if "entity" in elem:
-                    tag_filter_dict["entity"] = elem.get("entity")
-                tag_filters.append(DeprecatedTagFilter(**tag_filter_dict))
+            if elem.get("type") != "TAG_FILTER":
+                return {"error": f"EXPRESSION element of type {elem.get('type')!r} is not supported here. {self._UNSUPPORTED_FILTER_HINT}"}
+            result = self._convert_single_tag_filter(elem)
+            if isinstance(result, dict) and "error" in result:
+                return result
+            tag_filters.append(result)
         return tag_filters
 
     def _convert_tag_filter_to_deprecated(
@@ -512,8 +522,10 @@ class MobileAppAnalyzeMCPTools(BaseInstanaClient):
             - Dict with 'error' key: Conversion error occurred
             - Empty list: No filters to convert
         """
+        filter_type = tag_filter_expression.get("type")
+
         # Single TAG_FILTER
-        if tag_filter_expression.get("type") == "TAG_FILTER":
+        if filter_type == "TAG_FILTER":
             result = self._convert_single_tag_filter(tag_filter_expression)
             if isinstance(result, dict) and "error" in result:
                 return result
@@ -521,17 +533,23 @@ class MobileAppAnalyzeMCPTools(BaseInstanaClient):
             return [result]
 
         # EXPRESSION with elements
-        elif tag_filter_expression.get("type") == "EXPRESSION":
+        elif filter_type == "EXPRESSION":
+            logical_operator = tag_filter_expression.get("logicalOperator", "AND")
+            if logical_operator != "AND":
+                return {"error": f"logicalOperator {logical_operator!r} is not supported here. {self._UNSUPPORTED_FILTER_HINT}"}
             elements = tag_filter_expression.get("elements", [])
             if elements:
                 tag_filters = self._convert_expression_filters(elements)
+                if isinstance(tag_filters, dict) and "error" in tag_filters:
+                    return tag_filters
                 if tag_filters:
                     logger.debug(f"[get_mobile_app_beacons] Converted {len(tag_filters)} TAG_FILTERs from EXPRESSION")
                     return tag_filters
             else:
                 logger.debug("[get_mobile_app_beacons] Empty EXPRESSION - no tag filters applied")
+            return []
 
-        return []
+        return {"error": f"Tag filter type {filter_type!r} is not supported here. {self._UNSUPPORTED_FILTER_HINT}"}
 
     def _build_beacons_query_params(
         self,

--- a/src/website/website_analyze.py
+++ b/src/website/website_analyze.py
@@ -208,36 +208,57 @@ class WebsiteAnalyzeMCPTools(BaseInstanaClient):
         normalized.setdefault("offset", DEFAULT_BEACON_PAGINATION["offset"])
         return normalized
 
+    # The beacons list endpoint only accepts the API's deprecated `tagFilters`
+    # format: a flat, implicitly AND-combined list of TAG_FILTERs without a
+    # `key` field. Anything richer must be rejected loudly — silently dropping
+    # `key`, OR semantics or nested expressions would change the query meaning
+    # without any signal to the caller.
+    _UNSUPPORTED_FILTER_HINT = (
+        "The beacons list endpoint only supports a single TAG_FILTER or a flat, "
+        "AND-combined EXPRESSION of TAG_FILTERs, without a 'key' field. For "
+        "filters that need 'key' (e.g. beacon.meta sub-keys), OR, or nested "
+        "expressions, use get_website_beacon_groups instead."
+    )
+
+    def _convert_single_beacon_tag_filter(self, tag_filter: Dict[str, Any]) -> Dict[str, Any]:
+        if tag_filter.get("key"):
+            return {"error": f"TAG_FILTER with a 'key' field is not supported here. {self._UNSUPPORTED_FILTER_HINT}"}
+        name = tag_filter.get("name")
+        operator = tag_filter.get("operator")
+        value = tag_filter.get("value")
+        if not name or not operator or not value:
+            return {"error": "TAG_FILTER requires 'name', 'operator', and 'value' fields"}
+        tag_filter_dict = {"name": name, "operator": operator, "value": value}
+        if "entity" in tag_filter:
+            tag_filter_dict["entity"] = tag_filter.get("entity")
+        return tag_filter_dict
+
     def _convert_beacon_tag_filters(self, tag_filter_expression: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         if not tag_filter_expression:
             return {}
         try:
             from instana_client.models.deprecated_tag_filter import DeprecatedTagFilter
-            if tag_filter_expression.get("type") == "TAG_FILTER":
-                name = tag_filter_expression.get("name")
-                operator = tag_filter_expression.get("operator")
-                value = tag_filter_expression.get("value")
-                if not name or not operator or not value:
-                    return {"error": "TAG_FILTER requires 'name', 'operator', and 'value' fields"}
-                tag_filter_dict = {"name": name, "operator": operator, "value": value}
-                if "entity" in tag_filter_expression:
-                    tag_filter_dict["entity"] = tag_filter_expression.get("entity")
-                return {"tagFilters": [DeprecatedTagFilter(**tag_filter_dict)]}
-            if tag_filter_expression.get("type") == "EXPRESSION":
+            filter_type = tag_filter_expression.get("type")
+            if filter_type == "TAG_FILTER":
+                converted = self._convert_single_beacon_tag_filter(tag_filter_expression)
+                if "error" in converted:
+                    return converted
+                return {"tagFilters": [DeprecatedTagFilter(**converted)]}
+            if filter_type == "EXPRESSION":
+                logical_operator = tag_filter_expression.get("logicalOperator", "AND")
+                if logical_operator != "AND":
+                    return {"error": f"logicalOperator {logical_operator!r} is not supported here. {self._UNSUPPORTED_FILTER_HINT}"}
                 elements = tag_filter_expression.get("elements", [])
                 tag_filters = []
                 for elem in elements:
-                    if elem.get("type") == "TAG_FILTER":
-                        tag_filter_dict = {
-                            "name": elem.get("name"),
-                            "operator": elem.get("operator"),
-                            "value": elem.get("value"),
-                        }
-                        if "entity" in elem:
-                            tag_filter_dict["entity"] = elem.get("entity")
-                        tag_filters.append(DeprecatedTagFilter(**tag_filter_dict))
+                    if elem.get("type") != "TAG_FILTER":
+                        return {"error": f"EXPRESSION element of type {elem.get('type')!r} is not supported here. {self._UNSUPPORTED_FILTER_HINT}"}
+                    converted = self._convert_single_beacon_tag_filter(elem)
+                    if "error" in converted:
+                        return converted
+                    tag_filters.append(DeprecatedTagFilter(**converted))
                 return {"tagFilters": tag_filters} if tag_filters else {}
-            return {}
+            return {"error": f"Tag filter type {filter_type!r} is not supported here. {self._UNSUPPORTED_FILTER_HINT}"}
         except Exception as e:
             logger.error(f"[get_website_beacons] Error converting tag filter expression: {e}")
             return {"error": f"Invalid tag filter expression: {e!s}"}

--- a/tests/mobile_app/test_mobile_app_analyze.py
+++ b/tests/mobile_app/test_mobile_app_analyze.py
@@ -177,6 +177,64 @@ class TestMobileAppAnalyzeMCPTools(unittest.IsolatedAsyncioTestCase):
     def test_summarize_beacons_non_dict(self):
         self.assertEqual(self.client._summarize_beacons_response(["x"]), ["x"])
 
+    def test_convert_tag_filter_flat_and_expression(self):
+        result = self.client._convert_tag_filter_to_deprecated({
+            "type": "EXPRESSION", "logicalOperator": "AND",
+            "elements": [
+                {"type": "TAG_FILTER", "name": "mobileBeacon.view.name", "operator": "EQUALS", "entity": "NOT_APPLICABLE", "value": "Home"},
+                {"type": "TAG_FILTER", "name": "mobileBeacon.customEvent.name", "operator": "EQUALS", "entity": "NOT_APPLICABLE", "value": "my_event"},
+            ],
+        })
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+    def test_convert_tag_filter_rejects_key_in_single_filter(self):
+        result = self.client._convert_tag_filter_to_deprecated({
+            "type": "TAG_FILTER", "name": "mobileBeacon.meta", "key": "myKey",
+            "operator": "EQUALS", "entity": "NOT_APPLICABLE", "value": "some_value",
+        })
+        self.assertIsInstance(result, dict)
+        self.assertIn("'key'", result["error"])
+
+    def test_convert_tag_filter_rejects_key_in_expression_element(self):
+        result = self.client._convert_tag_filter_to_deprecated({
+            "type": "EXPRESSION", "logicalOperator": "AND",
+            "elements": [
+                {"type": "TAG_FILTER", "name": "mobileBeacon.meta", "key": "myKey", "operator": "EQUALS", "entity": "NOT_APPLICABLE", "value": "some_value"},
+            ],
+        })
+        self.assertIsInstance(result, dict)
+        self.assertIn("'key'", result["error"])
+
+    def test_convert_tag_filter_rejects_or_operator(self):
+        result = self.client._convert_tag_filter_to_deprecated({
+            "type": "EXPRESSION", "logicalOperator": "OR",
+            "elements": [
+                {"type": "TAG_FILTER", "name": "mobileBeacon.view.name", "operator": "EQUALS", "entity": "NOT_APPLICABLE", "value": "Home"},
+            ],
+        })
+        self.assertIsInstance(result, dict)
+        self.assertIn("OR", result["error"])
+
+    def test_convert_tag_filter_rejects_nested_expression(self):
+        result = self.client._convert_tag_filter_to_deprecated({
+            "type": "EXPRESSION", "logicalOperator": "AND",
+            "elements": [{"type": "EXPRESSION", "logicalOperator": "OR", "elements": []}],
+        })
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    def test_convert_tag_filter_rejects_unknown_type(self):
+        result = self.client._convert_tag_filter_to_deprecated({"type": "SOMETHING_ELSE"})
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    def test_convert_tag_filter_empty_expression_is_noop(self):
+        result = self.client._convert_tag_filter_to_deprecated({
+            "type": "EXPRESSION", "logicalOperator": "AND", "elements": [],
+        })
+        self.assertEqual(result, [])
+
     async def test_get_all_mobile_app_beacons_success(self):
         payload = {
             "totalHits": 1,

--- a/tests/website/test_website_analyze.py
+++ b/tests/website/test_website_analyze.py
@@ -278,6 +278,68 @@ class TestWebsiteAnalyzeMCPTools(unittest.TestCase):
         self.assertEqual(self.tools_instance.read_token, "test_token")
         self.assertEqual(self.tools_instance.base_url, "https://test.instana.io")
 
+    def test_convert_beacon_tag_filters_flat_and_expression(self):
+        """A flat AND expression of TAG_FILTERs converts successfully"""
+        result = self.tools_instance._convert_beacon_tag_filters({
+            "type": "EXPRESSION", "logicalOperator": "AND",
+            "elements": [
+                {"type": "TAG_FILTER", "name": "beacon.page.name", "operator": "EQUALS", "entity": "NOT_APPLICABLE", "value": "/home"},
+                {"type": "TAG_FILTER", "name": "beacon.customEvent.name", "operator": "EQUALS", "entity": "NOT_APPLICABLE", "value": "my_event"},
+            ],
+        })
+        self.assertNotIn("error", result)
+        self.assertEqual(len(result["tagFilters"]), 2)
+
+    def test_convert_beacon_tag_filters_rejects_key_in_single_filter(self):
+        """A 'key' field cannot be expressed in deprecated tagFilters — must error, not drop"""
+        result = self.tools_instance._convert_beacon_tag_filters({
+            "type": "TAG_FILTER", "name": "beacon.meta", "key": "myKey",
+            "operator": "EQUALS", "entity": "NOT_APPLICABLE", "value": "some_value",
+        })
+        self.assertIn("error", result)
+        self.assertIn("'key'", result["error"])
+
+    def test_convert_beacon_tag_filters_rejects_key_in_expression_element(self):
+        result = self.tools_instance._convert_beacon_tag_filters({
+            "type": "EXPRESSION", "logicalOperator": "AND",
+            "elements": [
+                {"type": "TAG_FILTER", "name": "beacon.meta", "key": "myKey", "operator": "EQUALS", "entity": "NOT_APPLICABLE", "value": "some_value"},
+            ],
+        })
+        self.assertIn("error", result)
+        self.assertIn("'key'", result["error"])
+
+    def test_convert_beacon_tag_filters_rejects_or_operator(self):
+        """Deprecated tagFilters are implicitly AND — OR must error, not silently change semantics"""
+        result = self.tools_instance._convert_beacon_tag_filters({
+            "type": "EXPRESSION", "logicalOperator": "OR",
+            "elements": [
+                {"type": "TAG_FILTER", "name": "beacon.page.name", "operator": "EQUALS", "entity": "NOT_APPLICABLE", "value": "/home"},
+            ],
+        })
+        self.assertIn("error", result)
+        self.assertIn("OR", result["error"])
+
+    def test_convert_beacon_tag_filters_rejects_nested_expression(self):
+        result = self.tools_instance._convert_beacon_tag_filters({
+            "type": "EXPRESSION", "logicalOperator": "AND",
+            "elements": [
+                {"type": "EXPRESSION", "logicalOperator": "OR", "elements": []},
+            ],
+        })
+        self.assertIn("error", result)
+
+    def test_convert_beacon_tag_filters_rejects_unknown_type(self):
+        result = self.tools_instance._convert_beacon_tag_filters({"type": "SOMETHING_ELSE"})
+        self.assertIn("error", result)
+
+    def test_convert_beacon_tag_filters_empty_expression_is_noop(self):
+        """An empty EXPRESSION means 'no filters' and must stay accepted"""
+        result = self.tools_instance._convert_beacon_tag_filters({
+            "type": "EXPRESSION", "logicalOperator": "AND", "elements": [],
+        })
+        self.assertEqual(result, {})
+
     @PATCH_CATALOG
     def test_get_beacon_groups_with_all_params(self, _mock_catalog):
         """Test get_website_beacon_groups with all parameters"""


### PR DESCRIPTION
## Problem

The beacons list endpoints (`get_website_beacons`, `get_all_mobile_app_beacons`) convert the caller's `tag_filter_expression` to the API's deprecated flat `tagFilters` format — the only format the SDK's `GetWebsiteBeacons`/`GetMobileAppBeacons` request models support. That format cannot express everything the modern `tagFilterExpression` can, and the conversion previously coped by **silently changing the query's meaning**:

| Caller sends | What actually happened |
|---|---|
| TAG_FILTER with `key` (sub-key of a key/value tag like `beacon.meta`) | `key` dropped → filter becomes a plain equals on the map itself → matches nothing, returns 0 hits |
| `logicalOperator: "OR"` | ignored → executed with AND semantics |
| nested EXPRESSION / non-TAG_FILTER elements | silently skipped |
| unknown top-level filter type | treated as "no filter at all" → unfiltered results |

All four produce plausible-looking responses with no signal that the query wasn't what the caller asked for. The first case is particularly costly to debug: `0 hits` is indistinguishable from "no matching data".

## Fix

Each unsupported construct now returns a clear error stating what the endpoint supports (a single TAG_FILTER or a flat, AND-combined EXPRESSION of TAG_FILTERs, without `key`) and pointing to the beacon-groups tools — which accept the full `tagFilterExpression` format — for key/OR/nested needs. Empty expressions remain a valid no-op (the mobile module passes one as its own default). Same behavior in both website and mobile modules.

## Tests

7 new tests per module: the four rejection cases (asserting the error names the offending part), the valid flat-AND path, and the empty-expression no-op.

`uv run test` passes (the only failure, `TestVersionImport.test_version_fallback_on_exception`, is pre-existing on `main`). `uv run ruff check .` passes.

Related: #125 (meta in beacon list output) and #126 (`groupbyTagSecondLevelKey` in group mapping) — together the three make custom-event meta workflows both possible and debuggable through the beacon analyze tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)