### PR TITLE
INSTA-109248 Fix oTelLLM analyze infra issue by adding a static metric list

### DIFF
--- a/src/infrastructure/infrastructure_catalog.py
+++ b/src/infrastructure/infrastructure_catalog.py
@@ -34,6 +34,26 @@ ERROR_PLUGIN_REQUIRED = "plugin parameter is required"
 _HINT_GET_PLUGINS = "First call get_plugins to discover available plugin IDs"
 _MSG_PLUGIN_MISSING = "Missing required parameter 'plugin'. Call get_plugins first to discover valid plugin IDs."
 
+# Static metric overrides for plugins whose tagged metrics are not exposed by the catalog API.
+# The catalog endpoint GET /catalog/metrics/{plugin} only returns untagged/builtin definitions;
+# tagged metrics (registered via the custom catalog path) are absent from its response.
+# Add an entry here whenever a plugin's full metric set cannot be discovered via the API.
+_STATIC_METRICS_OVERRIDE: Dict[str, List[str]] = {
+    "oTelLLM": [
+        "metrics.gauges.llm.usage.total_tokens",
+        "metrics.gauges.llm.usage.input_tokens",
+        "metrics.gauges.llm.usage.output_tokens",
+        "metrics.gauges.llm.usage.cost",
+        "metrics.gauges.llm.usage.input_cost",
+        "metrics.gauges.llm.usage.output_cost",
+        "metrics.gauges.llm.response.duration",
+        "metrics.gauges.llm.latency.per_token",
+        "metrics.sums.llm.request.count",
+        "__message_size",
+        "__message_count"
+    ],
+}
+
 class InfrastructureCatalogMCPTools(BaseInstanaClient):
     """Tools for infrastructure catalog in Instana MCP."""
 
@@ -621,28 +641,36 @@ class InfrastructureCatalogMCPTools(BaseInstanaClient):
                 "errors": []
             }
 
-            # Get metrics
-            try:
-                metrics = await self.get_infrastructure_catalog_metrics(
-                    plugin=plugin,
-                    filter=filter,
-                    ctx=ctx,
-                    api_client=api_client
+            # Get metrics — use static override for plugins whose tagged metrics are not
+            # returned by the catalog API (e.g. oTelLLM uses the tagged-metrics path).
+            if plugin in _STATIC_METRICS_OVERRIDE:
+                result["metrics"] = _STATIC_METRICS_OVERRIDE[plugin]
+                logger.debug(
+                    "Using static metric override for plugin '%s' (%d metrics)",
+                    plugin, len(result["metrics"])
                 )
+            else:
+                try:
+                    metrics = await self.get_infrastructure_catalog_metrics(
+                        plugin=plugin,
+                        filter=filter,
+                        ctx=ctx,
+                        api_client=api_client
+                    )
 
-                # Check if metrics call returned an error
-                if isinstance(metrics, dict) and "error" in metrics:
-                    result["errors"].append(f"Metrics: {metrics['error']}")
-                    result["metrics"] = []
-                elif isinstance(metrics, dict) and "metrics" in metrics:
-                    result["metrics"] = metrics["metrics"]
-                else:
-                    result["metrics"] = []
+                    # Check if metrics call returned an error
+                    if isinstance(metrics, dict) and "error" in metrics:
+                        result["errors"].append(f"Metrics: {metrics['error']}")
+                        result["metrics"] = []
+                    elif isinstance(metrics, dict) and "metrics" in metrics:
+                        result["metrics"] = metrics["metrics"]
+                    else:
+                        result["metrics"] = []
 
-            except Exception as e:
-                error_msg = f"Failed to get metrics: {e!s}"
-                logger.error(error_msg, exc_info=True)
-                result["errors"].append(error_msg)
+                except Exception as e:
+                    error_msg = f"Failed to get metrics: {e!s}"
+                    logger.error(error_msg, exc_info=True)
+                    result["errors"].append(error_msg)
 
             # Get tags
             try:

--- a/src/prompts/infrastructure/infrastructure_analyze.py
+++ b/src/prompts/infrastructure/infrastructure_analyze.py
@@ -4,7 +4,7 @@ Infrastructure Analyze MCP Prompts Module
 This module provides infrastructure analyze-specific MCP prompts for Instana monitoring.
 """
 
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Optional
 
 from src.prompts import auto_register_prompt
 
@@ -22,7 +22,9 @@ class InfrastructureAnalyzePrompts:
         windowSize: Optional[int] = None) -> str:
         """Get available infrastructure metrics for a given entity type"""
         return f"""
-        Get available infrastructure metrics:
+        Use the manage_infrastructure tool to get available metrics for an infrastructure entity type.
+        - resource_type: "catalog"
+        - operation: "get_plugin_schema"
         - Type: {type}
         - Query: {query if query is not None else 'None'}
         - From: {var_from if var_from is not None else 'None'}
@@ -39,7 +41,9 @@ class InfrastructureAnalyzePrompts:
         to: Optional[int] = None) -> str:
         """Fetch infrastructure entities and their metrics"""
         return f"""
-        Get infrastructure entities:
+        Use the manage_infrastructure tool to fetch infrastructure entities and their metrics.
+        - resource_type: "analyze"
+        - operation: "get_entities"
         - Type: {type}
         - Metrics: {metrics if metrics is not None else 'None'}
         - Window size: {windowSize if windowSize is not None else 'None'}
@@ -55,11 +59,98 @@ class InfrastructureAnalyzePrompts:
         to: Optional[int] = None) -> str:
         """List available infrastructure monitoring plugins"""
         return f"""
-        Get available infrastructure plugins:
+        Use the manage_infrastructure tool to list available infrastructure monitoring plugins.
+        - resource_type: "catalog"
+        - operation: "get_plugins"
         - Query: {query if query is not None else 'None'}
         - Offline: {offline}
         - Window size: {windowSize if windowSize is not None else 'None'}
         - To: {to if to is not None else 'None'}
+        """
+
+    @auto_register_prompt
+    @staticmethod
+    def llm_performance_and_token_queries() -> str:
+        """Route LLM performance and token correlation queries to infrastructure only."""
+        return """
+        Use the manage_infrastructure tool for all LLM and GenAI performance and token usage queries.
+         Do NOT use manage_applications tool.
+        - resource_type: "analyze"
+        - operation: "get_entities" or "get_entity_groups" depending on whether grouping is needed
+        - type: "oTelLLM" (for LLM/GenAI entities)
+        Covers service, .run.workflow, and GenAI App forms.
+        Covers highest latency P95, latency > P95, duration thresholds, and token usage over a time range.
+        Always call manage_infrastructure first with resource_type="catalog", operation="get_plugin_schema", plugin="oTelLLM"
+        to discover valid metrics and tags before querying.
+        """
+
+    @auto_register_prompt
+    @staticmethod
+    def list_llm_genai_apps() -> str:
+        """Route GenAI app listing queries to infrastructure only."""
+        return """
+        Use the manage_infrastructure tool to list or show GenAI apps.
+        Do NOT use manage_applications tool.
+        - resource_type: "resources"
+        - operation: "get_snapshots"
+        - plugin: "oTelLLM"
+        """
+
+    @auto_register_prompt
+    @staticmethod
+    def failed_llm_prompt_or_output() -> str:
+        """Route failed LLM prompt or output queries to infrastructure only."""
+        return """
+        Use the manage_infrastructure tool to show the most recent failed prompt or output for an LLM or GenAI service.
+        Do NOT use manage_applications tool.
+        - resource_type: "analyze"
+        - operation: "get_entities"
+        - type: "oTelLLM"
+        Filter by a relevant error or status metric/tag to identify failed calls.
+        """
+
+    @auto_register_prompt
+    @staticmethod
+    def total_llm_token_usage() -> str:
+        """Route total LLM token usage queries to infrastructure only."""
+        return """
+        Use the manage_infrastructure tool to get total token usage for an LLM or GenAI service over a time range.
+         Do NOT use manage_applications tool.
+        - resource_type: "analyze"
+        - operation: "get_entity_groups"
+        - type: "oTelLLM"
+        Use a token-related metric (e.g. "metrics.gauges.llm.usage.total_tokens") with aggregation "SUM".
+        Always call manage_infrastructure first with resource_type="catalog", operation="get_plugin_schema", plugin="oTelLLM"
+        to confirm valid metric names before querying.
+        """
+
+    @auto_register_prompt
+    @staticmethod
+    def llm_individual_trace_latency_and_tokens() -> str:
+        """Route queries for individual LLM workflow run latency (above P95) and tokens per run to infrastructure only.
+
+        Do NOT use manage_applications tool — this data is not available via call traces.
+
+        1. resource_type="catalog", operation="get_plugin_schema", plugin="oTelLLM"
+           to confirm valid metric names and tag names.
+
+        2. resource_type="analyze", operation="get_entities":
+           - type: "oTelLLM"
+           - Filter by the agent label (e.g. "payment-agent") using tagFilterExpression on the "label" tag.
+           - Use granularity 60000 ms for per-invocation resolution.
+           - Include latency.per_token, response.duration, total/input/output tokens, and request.count metrics.
+           - timeFrame: windowSize 3600000 (last 1 hour) unless specified otherwise.
+
+        3. Treat each non-zero 2-minute bucket as one workflow invocation.
+           Compute P95 across all non-zero latency values.
+           Present only invocations exceeding P95 in a table:
+               Time (UTC) | Latency/Token (ms) | Response Duration (ms) | Total Tokens | Input Tokens | Output Tokens
+        """
+        return """
+        Do NOT use manage_applications tool — this data is not available via call traces.
+        Use manage_infrastructure with type "oTelLLM", filtered by the agent label, at fine granularity (60s)
+        to get per-invocation time-series. Compute P95 across non-zero latency buckets and present only
+        invocations exceeding it in a table.
         """
 
     @classmethod
@@ -69,4 +160,9 @@ class InfrastructureAnalyzePrompts:
             ('infra_available_metrics', cls.infra_available_metrics),
             ('infra_get_entities', cls.infra_get_entities),
             ('infra_available_plugins', cls.infra_available_plugins),
+            ('llm_performance_and_token_queries', cls.llm_performance_and_token_queries),
+            ('list_llm_genai_apps', cls.list_llm_genai_apps),
+            ('failed_llm_prompt_or_output', cls.failed_llm_prompt_or_output),
+            ('total_llm_token_usage', cls.total_llm_token_usage),
+            ('llm_individual_trace_latency_and_tokens', cls.llm_individual_trace_latency_and_tokens),
         ]

--- a/src/router/infrastructure_smart_router_tool.py
+++ b/src/router/infrastructure_smart_router_tool.py
@@ -93,7 +93,8 @@ RECOMMENDED WORKFLOW FOR ANALYZE:
     2. SECOND: Call get_plugin_schema with a VALID plugin ID from step 1
        - Combines get_metrics + get_tag_catalog into ONE efficient call
        - IMPORTANT: Plugin ID must be from get_plugins - invalid IDs return HTTP 400
-       - Returns: {"metrics": ["memory.usage", ...], "tags": ["host.name", ...]}
+       - Returns: {"metrics": ["memory.usage", ...], "tags": ["tag.name", ...]}
+       - tagFilterExpression is OPTIONAL — only add a filter when the user explicitly names a specific entity to filter by
 
     3. THIRD: Use the discovered entity types, metrics, and tags in analyze operations
        - Build queries with proper type, metrics, and tagFilterExpression
@@ -147,7 +148,7 @@ CATALOG (resource_type="catalog"):
         This is the FIRST step - discover what entity types are available in your environment
 
     get_plugin_schema - Get complete schema (metrics + tags) for a plugin in ONE call (RECOMMENDED)
-        - plugin (required): Plugin ID from get_plugins (e.g., "host", "jvmRuntimePlatform")
+        - plugin (required): Plugin ID from get_plugins (e.g., "host", "jvmRuntimePlatform", "oTelLLM")
         - filter (optional): "builtin" or "custom" to filter metric types
         Returns: Dictionary with both metrics and tags for the plugin
         {
@@ -159,13 +160,13 @@ CATALOG (resource_type="catalog"):
         This COMBINES get_metrics and get_tag_catalog into a single call
 
     get_metrics - Get infrastructure metrics catalog for a specific plugin
-        - plugin (required): Plugin ID from get_plugins (e.g., "host", "jvmRuntimePlatform")
+        - plugin (required): Plugin ID from get_plugins (e.g., "host", "jvmRuntimePlatform", "oTelLLM")
         - filter (optional): "builtin" or "custom" to filter metric types
         Returns: List of metric names available for the plugin
         Use returned metric names exactly in analyze operations
 
     get_tag_catalog - Get valid tag names for a specific plugin
-        - plugin (required): Plugin ID from get_plugins (e.g., "host", "kubernetesPod")
+        - plugin (required): Plugin ID from get_plugins (e.g., "host", "kubernetesPod", "oTelLLM")
         Returns: Available tag names for filtering and grouping
         Use returned tag names exactly in analyze operations
 
@@ -185,7 +186,7 @@ RESOURCES (resource_type="resources"):
         - from_time (optional): Start timestamp in milliseconds (default: 1 hour ago)
         - to_time (optional): End timestamp in milliseconds (default: now)
         - size (optional): Maximum number of results to return (default: 100)
-        - plugin (optional): Entity type to filter by (e.g., "host", "jvmRuntimePlatform")
+        - plugin (optional): Entity type to filter by (e.g., "host", "jvmRuntimePlatform", "oTelLLM")
         - offline (optional): Include offline snapshots (default: false)
         - detailed (optional): Return full raw data vs summarized (default: false)
         Returns: List of snapshots matching the search criteria
@@ -207,7 +208,7 @@ Examples:
     resource_type="catalog", operation="get_tag_catalog", params={"plugin": "host"}
     resource_type="analyze", operation="get_entities", params={"payload": {"type": "host", "metrics": [{"metric": "cpu.used", "granularity": 3600000, "aggregation": "MEAN"}], "timeFrame": {"windowSize": 3600000}}}
     resource_type="analyze", operation="get_entities", params={"payload": {"type": "jvmRuntimePlatform", "metrics": [{"metric": "memory.used", "granularity": 3600000, "aggregation": "MAX"}, {"metric": "threads.blocked", "granularity": 3600000, "aggregation": "MEAN"}], "timeFrame": {"to": 1743923995000, "windowSize": 3600000}, "tagFilterExpression": {"type": "TAG_FILTER", "entity": "NOT_APPLICABLE", "name": "host.name", "operator": "EQUALS", "value": "server1"}, "pagination": {"retrievalSize": 200}}}
-    resource_type="analyze", operation="get_entity_groups", params={"payload": {"type": "kubernetesPod", "groupBy": ["kubernetes.namespace.name"], "metrics": [{"metric": "cpu.requests", "granularity": 3600000, "aggregation": "SUM"}], "timeFrame": {"windowSize": 7200000}, "tagFilterExpression": {"type": "EXPRESSION", "logicalOperator": "AND", "elements": []}, "pagination": {"retrievalSize": 20}, "order": {"by": "label", "direction": "ASC"}}}
+    resource_type="analyze", operation="get_entity_groups", params={"payload": {"type": "oTelLLM", "groupBy": ["otel.attribute.service.name"], "metrics": [{"metric": "metrics.gauges.llm.usage.total_tokens", "granularity": 3600000, "aggregation": "SUM"}], "timeFrame": {"windowSize": 3600000}, "tagFilterExpression": {"type": "TAG_FILTER", "entity": "NOT_APPLICABLE", "name": "otel.attribute.service.name", "operator": "EQUALS", "value": "dispatch-agent"}, "pagination": {"retrievalSize": 20}}}
     resource_type="resources", operation="get_snapshot", params={"snapshot_id": "abc123xyz"}
     resource_type="resources", operation="get_snapshots", params={"plugin": "host", "size": 50}
     resource_type="resources", operation="get_snapshots", params={"query": "high cpu", "from_time": 1617994800000, "to_time": 1618081200000, "detailed": true}"""

--- a/tests/infrastructure/test_infrastructure_catalog.py
+++ b/tests/infrastructure/test_infrastructure_catalog.py
@@ -946,6 +946,59 @@ class TestInfrastructureCatalogMCPTools(unittest.TestCase):
         self.assertEqual(result['total'], 50)
         self.assertEqual(result['plugin'], "host")
 
+    # -------------------------------------------------------------------------
+    # get_plugin_schema — static metric override tests
+    # -------------------------------------------------------------------------
+
+    def test_get_plugin_schema_otel_llm_uses_static_metrics(self):
+        """get_plugin_schema for oTelLLM must use the static override and never call
+        the catalog metrics API, because tagged metrics are absent from that endpoint."""
+        # Tag catalog returns something minimal so the schema call can complete
+        self.catalog_api.get_tag_catalog.return_value = {}
+
+        result = asyncio.run(self.client.get_plugin_schema(plugin="oTelLLM"))
+
+        # The catalog metrics endpoint must NOT have been called
+        self.catalog_api.get_infrastructure_catalog_metrics_without_preload_content.assert_not_called()
+        # The result must carry metrics
+        self.assertIn("metrics", result)
+        self.assertGreater(len(result["metrics"]), 0)
+
+    def test_get_plugin_schema_otel_llm_static_metrics_content(self):
+        """get_plugin_schema for oTelLLM must return the exact authoritative metric names."""
+        self.catalog_api.get_tag_catalog.return_value = {}
+
+        result = asyncio.run(self.client.get_plugin_schema(plugin="oTelLLM"))
+
+        expected = {
+            "metrics.gauges.llm.usage.total_tokens",
+            "metrics.gauges.llm.usage.input_tokens",
+            "metrics.gauges.llm.usage.output_tokens",
+            "metrics.gauges.llm.usage.cost",
+            "metrics.gauges.llm.usage.input_cost",
+            "metrics.gauges.llm.usage.output_cost",
+            "metrics.gauges.llm.response.duration",
+            "metrics.gauges.llm.latency.per_token",
+            "metrics.sums.llm.request.count",
+            "__message_size",
+            "__message_count"
+        }
+        self.assertEqual(set(result["metrics"]), expected)
+
+    def test_get_plugin_schema_non_override_plugin_still_calls_catalog(self):
+        """get_plugin_schema for a normal plugin (e.g. 'host') must still call the
+        catalog metrics API — the static override must not affect other plugins."""
+        response = MagicMock()
+        response.status = 200
+        response.data = b'["cpu.used", "memory.used"]'
+        self.catalog_api.get_infrastructure_catalog_metrics_without_preload_content.return_value = response
+        self.catalog_api.get_tag_catalog.return_value = {}
+
+        result = asyncio.run(self.client.get_plugin_schema(plugin="host"))
+
+        self.catalog_api.get_infrastructure_catalog_metrics_without_preload_content.assert_called_once()
+        self.assertIn("metrics", result)
+        self.assertEqual(result["metrics"], ["cpu.used", "memory.used"])
 
 
 if __name__ == '__main__':

--- a/tests/prompts/infrastructure/test_infrastructure_analyze.py
+++ b/tests/prompts/infrastructure/test_infrastructure_analyze.py
@@ -1,6 +1,5 @@
 """Tests for the InfrastructureAnalyzePrompts class."""
 import unittest
-from unittest.mock import patch
 
 from src.prompts import PROMPT_REGISTRY
 from src.prompts.infrastructure.infrastructure_analyze import (
@@ -11,9 +10,12 @@ from src.prompts.infrastructure.infrastructure_analyze import (
 class TestInfrastructureAnalyzePrompts(unittest.TestCase):
     """Test cases for the InfrastructureAnalyzePrompts class."""
 
+    # ------------------------------------------------------------------
+    # Registry registration tests
+    # ------------------------------------------------------------------
+
     def test_infra_available_metrics_registered(self):
         """Test that infra_available_metrics is registered in the prompt registry."""
-        # The registry contains staticmethod objects, so we need to unwrap them
         func = InfrastructureAnalyzePrompts.infra_available_metrics
         self.assertTrue(any(
             getattr(item, '__func__', item) == func
@@ -22,7 +24,6 @@ class TestInfrastructureAnalyzePrompts(unittest.TestCase):
 
     def test_infra_get_entities_registered(self):
         """Test that infra_get_entities is registered in the prompt registry."""
-        # The registry contains staticmethod objects, so we need to unwrap them
         func = InfrastructureAnalyzePrompts.infra_get_entities
         self.assertTrue(any(
             getattr(item, '__func__', item) == func
@@ -31,20 +32,248 @@ class TestInfrastructureAnalyzePrompts(unittest.TestCase):
 
     def test_infra_available_plugins_registered(self):
         """Test that infra_available_plugins is registered in the prompt registry."""
-        # The registry contains staticmethod objects, so we need to unwrap them
         func = InfrastructureAnalyzePrompts.infra_available_plugins
         self.assertTrue(any(
             getattr(item, '__func__', item) == func
             for item in PROMPT_REGISTRY
         ))
 
+    def test_llm_performance_and_token_queries_registered(self):
+        """Test that llm_performance_and_token_queries is registered in the prompt registry."""
+        func = InfrastructureAnalyzePrompts.llm_performance_and_token_queries
+        self.assertTrue(any(
+            getattr(item, '__func__', item) == func
+            for item in PROMPT_REGISTRY
+        ))
+
+    def test_list_llm_genai_apps_registered(self):
+        """Test that list_llm_genai_apps is registered in the prompt registry."""
+        func = InfrastructureAnalyzePrompts.list_llm_genai_apps
+        self.assertTrue(any(
+            getattr(item, '__func__', item) == func
+            for item in PROMPT_REGISTRY
+        ))
+
+    def test_failed_llm_prompt_or_output_registered(self):
+        """Test that failed_llm_prompt_or_output is registered in the prompt registry."""
+        func = InfrastructureAnalyzePrompts.failed_llm_prompt_or_output
+        self.assertTrue(any(
+            getattr(item, '__func__', item) == func
+            for item in PROMPT_REGISTRY
+        ))
+
+    def test_total_llm_token_usage_registered(self):
+        """Test that total_llm_token_usage is registered in the prompt registry."""
+        func = InfrastructureAnalyzePrompts.total_llm_token_usage
+        self.assertTrue(any(
+            getattr(item, '__func__', item) == func
+            for item in PROMPT_REGISTRY
+        ))
+
+    def test_llm_individual_trace_latency_and_tokens_registered(self):
+        """Test that llm_individual_trace_latency_and_tokens is registered in the prompt registry."""
+        func = InfrastructureAnalyzePrompts.llm_individual_trace_latency_and_tokens
+        self.assertTrue(any(
+            getattr(item, '__func__', item) == func
+            for item in PROMPT_REGISTRY
+        ))
+
+    # ------------------------------------------------------------------
+    # get_prompts() shape tests
+    # ------------------------------------------------------------------
+
     def test_get_prompts_returns_all_prompts(self):
-        """Test that get_prompts returns all prompts defined in the class."""
+        """Test that get_prompts returns all 8 prompts in the correct order."""
         prompts = InfrastructureAnalyzePrompts.get_prompts()
-        self.assertEqual(len(prompts), 3)
-        self.assertEqual(prompts[0][0], 'infra_available_metrics')
-        self.assertEqual(prompts[1][0], 'infra_get_entities')
-        self.assertEqual(prompts[2][0], 'infra_available_plugins')
+        self.assertEqual(len(prompts), 8)
+        names = [p[0] for p in prompts]
+        self.assertEqual(names, [
+            'infra_available_metrics',
+            'infra_get_entities',
+            'infra_available_plugins',
+            'llm_performance_and_token_queries',
+            'list_llm_genai_apps',
+            'failed_llm_prompt_or_output',
+            'total_llm_token_usage',
+            'llm_individual_trace_latency_and_tokens',
+        ])
+
+    # ------------------------------------------------------------------
+    # infra_available_metrics content tests
+    # ------------------------------------------------------------------
+
+    def test_infra_available_metrics_contains_tool_instruction(self):
+        """Test that infra_available_metrics output directs to manage_infrastructure."""
+        result = InfrastructureAnalyzePrompts.infra_available_metrics(type='host')
+        self.assertIn('manage_infrastructure', result)
+        self.assertIn('resource_type: "catalog"', result)
+        self.assertIn('operation: "get_plugin_schema"', result)
+
+    def test_infra_available_metrics_with_all_params(self):
+        """Test that infra_available_metrics interpolates all provided parameters."""
+        result = InfrastructureAnalyzePrompts.infra_available_metrics(
+            type='host', query='cpu', var_from=1000, to=2000, windowSize=3600000
+        )
+        self.assertIn('host', result)
+        self.assertIn('cpu', result)
+        self.assertIn('1000', result)
+        self.assertIn('2000', result)
+        self.assertIn('3600000', result)
+
+    def test_infra_available_metrics_none_defaults(self):
+        """Test that optional params default to 'None' string when not provided."""
+        result = InfrastructureAnalyzePrompts.infra_available_metrics(type='jvmRuntimePlatform')
+        self.assertIn('jvmRuntimePlatform', result)
+        self.assertIn('None', result)
+
+    # ------------------------------------------------------------------
+    # infra_get_entities content tests
+    # ------------------------------------------------------------------
+
+    def test_infra_get_entities_contains_tool_instruction(self):
+        """Test that infra_get_entities output directs to manage_infrastructure."""
+        result = InfrastructureAnalyzePrompts.infra_get_entities(type='host')
+        self.assertIn('manage_infrastructure', result)
+        self.assertIn('resource_type: "analyze"', result)
+        self.assertIn('operation: "get_entities"', result)
+
+    def test_infra_get_entities_with_all_params(self):
+        """Test that infra_get_entities interpolates all provided parameters."""
+        result = InfrastructureAnalyzePrompts.infra_get_entities(
+            type='host', metrics='cpu.used', windowSize=3600000, to=9999999
+        )
+        self.assertIn('host', result)
+        self.assertIn('cpu.used', result)
+        self.assertIn('3600000', result)
+        self.assertIn('9999999', result)
+
+    def test_infra_get_entities_none_defaults(self):
+        """Test that optional params default to 'None' string when not provided."""
+        result = InfrastructureAnalyzePrompts.infra_get_entities(type='host')
+        self.assertIn('None', result)
+
+    # ------------------------------------------------------------------
+    # infra_available_plugins content tests
+    # ------------------------------------------------------------------
+
+    def test_infra_available_plugins_contains_tool_instruction(self):
+        """Test that infra_available_plugins output directs to manage_infrastructure."""
+        result = InfrastructureAnalyzePrompts.infra_available_plugins(offline=False)
+        self.assertIn('manage_infrastructure', result)
+        self.assertIn('resource_type: "catalog"', result)
+        self.assertIn('operation: "get_plugins"', result)
+
+    def test_infra_available_plugins_with_all_params(self):
+        """Test that infra_available_plugins interpolates all provided parameters."""
+        result = InfrastructureAnalyzePrompts.infra_available_plugins(
+            offline=True, query='k8s', windowSize=1800000, to=12345
+        )
+        self.assertIn('True', result)
+        self.assertIn('k8s', result)
+        self.assertIn('1800000', result)
+        self.assertIn('12345', result)
+
+    def test_infra_available_plugins_none_defaults(self):
+        """Test that optional params default to 'None' string when not provided."""
+        result = InfrastructureAnalyzePrompts.infra_available_plugins(offline=False)
+        self.assertIn('None', result)
+
+    # ------------------------------------------------------------------
+    # llm_performance_and_token_queries content tests
+    # ------------------------------------------------------------------
+
+    def test_llm_performance_and_token_queries_uses_infrastructure(self):
+        """Test that the prompt routes to manage_infrastructure and not manage_applications."""
+        result = InfrastructureAnalyzePrompts.llm_performance_and_token_queries()
+        self.assertIn('manage_infrastructure', result)
+        self.assertIn('Do NOT use manage_applications', result)
+
+    def test_llm_performance_and_token_queries_specifies_otelllm(self):
+        """Test that the prompt specifies the oTelLLM entity type."""
+        result = InfrastructureAnalyzePrompts.llm_performance_and_token_queries()
+        self.assertIn('oTelLLM', result)
+
+    def test_llm_performance_and_token_queries_mentions_get_plugin_schema(self):
+        """Test that the prompt instructs to call get_plugin_schema first."""
+        result = InfrastructureAnalyzePrompts.llm_performance_and_token_queries()
+        self.assertIn('get_plugin_schema', result)
+
+    # ------------------------------------------------------------------
+    # list_llm_genai_apps content tests
+    # ------------------------------------------------------------------
+
+    def test_list_llm_genai_apps_uses_infrastructure(self):
+        """Test that the prompt routes to manage_infrastructure and not manage_applications."""
+        result = InfrastructureAnalyzePrompts.list_llm_genai_apps()
+        self.assertIn('manage_infrastructure', result)
+        self.assertIn('Do NOT use manage_applications', result)
+
+    def test_list_llm_genai_apps_specifies_resources_and_snapshots(self):
+        """Test that the prompt specifies the resources/get_snapshots operation."""
+        result = InfrastructureAnalyzePrompts.list_llm_genai_apps()
+        self.assertIn('resource_type: "resources"', result)
+        self.assertIn('operation: "get_snapshots"', result)
+        self.assertIn('oTelLLM', result)
+
+    # ------------------------------------------------------------------
+    # failed_llm_prompt_or_output content tests
+    # ------------------------------------------------------------------
+
+    def test_failed_llm_prompt_or_output_uses_infrastructure(self):
+        """Test that the prompt routes to manage_infrastructure and not manage_applications."""
+        result = InfrastructureAnalyzePrompts.failed_llm_prompt_or_output()
+        self.assertIn('manage_infrastructure', result)
+        self.assertIn('Do NOT use manage_applications', result)
+
+    def test_failed_llm_prompt_or_output_specifies_analyze_get_entities(self):
+        """Test that the prompt specifies the analyze/get_entities operation."""
+        result = InfrastructureAnalyzePrompts.failed_llm_prompt_or_output()
+        self.assertIn('resource_type: "analyze"', result)
+        self.assertIn('operation: "get_entities"', result)
+        self.assertIn('oTelLLM', result)
+
+    # ------------------------------------------------------------------
+    # total_llm_token_usage content tests
+    # ------------------------------------------------------------------
+
+    def test_total_llm_token_usage_uses_infrastructure(self):
+        """Test that the prompt routes to manage_infrastructure and not manage_applications."""
+        result = InfrastructureAnalyzePrompts.total_llm_token_usage()
+        self.assertIn('manage_infrastructure', result)
+        self.assertIn('Do NOT use manage_applications', result)
+
+    def test_total_llm_token_usage_specifies_entity_groups(self):
+        """Test that the prompt specifies the analyze/get_entity_groups operation."""
+        result = InfrastructureAnalyzePrompts.total_llm_token_usage()
+        self.assertIn('resource_type: "analyze"', result)
+        self.assertIn('operation: "get_entity_groups"', result)
+        self.assertIn('oTelLLM', result)
+
+    def test_total_llm_token_usage_mentions_token_metric(self):
+        """Test that the prompt references a token usage metric."""
+        result = InfrastructureAnalyzePrompts.total_llm_token_usage()
+        self.assertIn('metrics.gauges.llm.usage.total_tokens', result)
+        self.assertIn('get_plugin_schema', result)
+
+    # ------------------------------------------------------------------
+    # llm_individual_trace_latency_and_tokens content tests
+    # ------------------------------------------------------------------
+
+    def test_llm_individual_trace_latency_and_tokens_uses_infrastructure(self):
+        """Test that the prompt routes to manage_infrastructure and not manage_applications."""
+        result = InfrastructureAnalyzePrompts.llm_individual_trace_latency_and_tokens()
+        self.assertIn('manage_infrastructure', result)
+        self.assertIn('Do NOT use manage_applications', result)
+
+    def test_llm_individual_trace_latency_and_tokens_specifies_otelllm(self):
+        """Test that the prompt specifies the oTelLLM type."""
+        result = InfrastructureAnalyzePrompts.llm_individual_trace_latency_and_tokens()
+        self.assertIn('oTelLLM', result)
+
+    def test_llm_individual_trace_latency_and_tokens_mentions_p95(self):
+        """Test that the prompt refers to P95 computation."""
+        result = InfrastructureAnalyzePrompts.llm_individual_trace_latency_and_tokens()
+        self.assertIn('P95', result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Adds LLM/GenAI observability support to infrastructure monitoring by routing `oTelLLM` queries through `manage_infrastructure`.

The Instana catalog API does not currently return the tagged metrics for `oTelLLM`, so a static metric definition is used for this plugin to ensure the agent can build valid queries.

## Changes

### Infrastructure

- Added `oTelLLM` metric definitions as a static override when retrieving the plugin schema.
- Updated infrastructure prompts to guide LLM/GenAI queries to `manage_infrastructure`.
- Added prompts for common LLM/GenAI use cases, including:
  - LLM performance and token usage
  - GenAI application discovery
  - Failed LLM calls
  - Aggregated token usage
  - Individual invocation latency and token analysis
- Updated infrastructure tool documentation with `oTelLLM` examples and clarified when `tagFilterExpression` is required.

### Testing

- Added tests for the `oTelLLM` metric override.
- Added coverage for all new prompts and their tool routing.
- Updated existing prompt tests for the expanded prompt set.

## Motivation

`oTelLLM` metrics are not returned by the catalog API because they are registered through the tagged-metrics path. Without the override, the agent receives an empty metric list and cannot reliably construct LLM/GenAI queries.

The new prompts also make the intended routing explicit so that LLM/GenAI queries are handled through infrastructure monitoring rather than application monitoring.