### PR TITLE
INSTA-11055: Update events default time window to 10 mins

### DIFF
--- a/src/event/events_tools.py
+++ b/src/event/events_tools.py
@@ -36,7 +36,7 @@ MS_PER_WEEK = 7 * MS_PER_DAY
 MS_PER_MONTH = 30 * MS_PER_DAY
 
 # Default values
-DEFAULT_TIME_WINDOW_HOURS = 24
+DEFAULT_TIME_WINDOW_MINUTES = 10
 DEFAULT_MAX_EVENTS = 50
 DEFAULT_SIZE = 100
 
@@ -103,25 +103,18 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
         elif time_range:
             # Convert time_range to window_size
             window_size_param = self._convert_time_range_to_window_size(time_range)
-            if window_size_param:
-                api_params[API_PARAM_WINDOW_SIZE] = window_size_param
-                logger.debug(
-                    f"[_build_time_params] Using window_size from time_range '{time_range}' - "
-                    f"window_size: {window_size_param}ms ({window_size_param/MS_PER_MINUTE:.1f} minutes)"
-                )
-                # For display purposes, calculate from/to times
-                current_time_ms = int(datetime.now().timestamp() * 1000)
-                to_time = current_time_ms
-                from_time = current_time_ms - window_size_param
-            else:
-                # Fallback to default
-                logger.debug(f"[_build_time_params] Failed to parse time_range '{time_range}', using defaults")
-                from_time, to_time = self._process_time_range(None, None, None)
-                api_params[API_PARAM_FROM] = from_time
-                api_params[API_PARAM_TO] = to_time
+            api_params[API_PARAM_WINDOW_SIZE] = window_size_param
+            logger.debug(
+                f"[_build_time_params] Using window_size from time_range '{time_range}' - "
+                f"window_size: {window_size_param}ms ({window_size_param/MS_PER_MINUTE:.1f} minutes)"
+            )
+            # For display purposes, calculate from/to times
+            current_time_ms = int(datetime.now().timestamp() * 1000)
+            to_time = current_time_ms
+            from_time = current_time_ms - window_size_param
         else:
             # No time parameters provided, use defaults
-            logger.debug(f"[_build_time_params] No time parameters provided, using default {DEFAULT_TIME_WINDOW_HOURS} hours")
+            logger.debug(f"[_build_time_params] No time parameters provided, using default {DEFAULT_TIME_WINDOW_MINUTES} minutes")
             from_time, to_time = self._process_time_range(None, None, None)
             api_params[API_PARAM_FROM] = from_time
             api_params[API_PARAM_TO] = to_time
@@ -140,7 +133,7 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
             time_range: Natural language time range like "last 5 minutes", "last 24 hours"
 
         Returns:
-            Window size in milliseconds, or None if cannot parse
+            Window size in milliseconds
         """
         if not time_range:
             return None
@@ -166,8 +159,8 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
                 logger.debug(f"[_convert_time_range_to_window_size] Parsed {hours} hours = {window_size}ms")
                 return window_size
             elif time_range_lower in ["last few hours", "last hours", "few hours"]:
-                window_size = DEFAULT_TIME_WINDOW_HOURS * MS_PER_HOUR
-                logger.debug(f"[_convert_time_range_to_window_size] Using default {DEFAULT_TIME_WINDOW_HOURS} hours = {window_size}ms")
+                window_size = DEFAULT_TIME_WINDOW_MINUTES * MS_PER_MINUTE
+                logger.debug(f"[_convert_time_range_to_window_size] Using default {DEFAULT_TIME_WINDOW_MINUTES} minutes = {window_size}ms")
                 return window_size
 
         # Extract days
@@ -197,9 +190,9 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
                 logger.debug(f"[_convert_time_range_to_window_size] Parsed {months} months = {window_size}ms")
                 return window_size
 
-        # Default to 24 hours
-        window_size = DEFAULT_TIME_WINDOW_HOURS * MS_PER_HOUR
-        logger.debug(f"[_convert_time_range_to_window_size] No match found, using default {DEFAULT_TIME_WINDOW_HOURS} hours = {window_size}ms")
+        # Default to 10 minutes
+        window_size = DEFAULT_TIME_WINDOW_MINUTES * MS_PER_MINUTE
+        logger.debug(f"[_convert_time_range_to_window_size] No match found, using default {DEFAULT_TIME_WINDOW_MINUTES} minutes = {window_size}ms")
         return window_size
 
     def _process_time_range(self, time_range=None, from_time=None, to_time=None):
@@ -231,7 +224,7 @@ class AgentMonitoringEventsMCPTools(BaseInstanaClient):
         if not to_time:
             to_time = current_time_ms
         if not from_time:
-            from_time = to_time - (24 * 60 * 60 * 1000)  # Default to 24 hours
+            from_time = to_time - (DEFAULT_TIME_WINDOW_MINUTES * MS_PER_MINUTE)  # Default to 10 minutes
 
         return from_time, to_time
 

--- a/src/prompts/events/events_tools.py
+++ b/src/prompts/events/events_tools.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from src.prompts import auto_register_prompt
 
@@ -28,7 +28,7 @@ class EventsPrompts:
         """Get Kubernetes info events and analyze them"""
         return f"""
         Get Kubernetes info events:
-        - From time: {from_time or '(default: 24 hours ago)'}
+        - From time: {from_time or '(not specified)'}
         - To time: {to_time or '(default: current time)'}
         - Time range: {time_range or '(not specified)'}
         - Max events: {max_events}
@@ -40,7 +40,7 @@ class EventsPrompts:
         query: Optional[str] = None,
         from_time: Optional[int] = None,
         to_time: Optional[int] = None,
-        size: Optional[int] = 100,
+        size: Optional[int] = None,
         max_events: Optional[int] = 50,
         time_range: Optional[str] = None
     ) -> str:
@@ -48,11 +48,43 @@ class EventsPrompts:
         return f"""
         Get Agent monitoring events:
         - Query: {query or '(not specified)'}
-        - From time: {from_time or '(default: 1 hour ago)'}
+        - From time: {from_time or '(default: 10 minutes)'}
         - To time: {to_time or '(default: current time)'}
-        - Size: {size}
+        - Size: {size or '(not specified)'}
         - Max events: {max_events}
         - Time range: {time_range or '(not specified)'}
+        """
+
+    @auto_register_prompt
+    @staticmethod
+    def get_events(
+        time_range: Optional[str] = None,
+        from_time: Optional[int] = None,
+        to_time: Optional[int] = None,
+        event_type_filters: Optional[List[str]] = None,
+        entity_type: Optional[str] = None,
+        entity_name: Optional[str] = None,
+        entity_label: Optional[str] = None,
+        state: Optional[str] = None,
+        problem: Optional[str] = None,
+        severity: Optional[int] = None,
+        max_events: Optional[int] = 50
+    ) -> str:
+        """Get events with flexible filtering by type, entity, severity, state and problem"""
+        no_time = not time_range and not from_time and not to_time
+        return f"""
+        Get events:
+        - Time range: {time_range or ('(not specified - defaulting to last 10 minutes)' if no_time else '(not specified)')}
+        - From time: {from_time or ('(not specified - defaulting to last 10 minutes)' if no_time else '(not specified)')}
+        - To time: {to_time or '(not specified - defaulting to current time)'}
+        - Event type filters: {event_type_filters or '(not specified)'}
+        - Entity type: {entity_type or '(not specified)'}
+        - Entity name: {entity_name or '(not specified)'}
+        - Entity label: {entity_label or '(not specified)'}
+        - State: {state or '(not specified)'}
+        - Problem: {problem or '(not specified)'}
+        - Severity: {severity or '(not specified)'}
+        - Max events: {max_events}
         """
 
     @auto_register_prompt
@@ -62,20 +94,18 @@ class EventsPrompts:
         to_time: Optional[int] = None,
         state: Optional[str] = None,
         severity: Optional[int] = None,
-        event_type_filters: Optional[list[str]] = None,
+        event_type_filters: Optional[List[str]] = None,
         max_events: Optional[int] = 50
     ) -> str:
         """Show me all closed issues with severity higher than 5, group by metrics, for Apr 22 from 10 to 11 am """
         return f"""
         Get events using filters:
-        {{
-            - From time: {from_time or 1745383800000} (Apr 22, 2025 10:00 AM)
-            - To time: {to_time or 1745387400000} (Apr 22, 2025 11:00 AM)
-            - State: {state or 'closed'}
-            - Severity: {severity or 10} (critical)
-            - Event type filters: {event_type_filters or '["ISSUE"]'}
-            - Max events: {max_events}
-        }}
+        - From time: {from_time or 1745383800000} (Apr 22, 2025 10:00 AM)
+        - To time: {to_time or 1745387400000} (Apr 22, 2025 11:00 AM)
+        - State: {state or 'closed'}
+        - Severity: {severity or 10} (critical)
+        - Event type filters: {event_type_filters or '["ISSUE"]'}
+        - Max events: {max_events}
         """
 
     @auto_register_prompt
@@ -84,19 +114,17 @@ class EventsPrompts:
         time_range: Optional[str] = None,
         entity_name: Optional[str] = None,
         problem: Optional[str] = None,
-        event_type_filters: Optional[list[str]] = None,
+        event_type_filters: Optional[List[str]] = None,
         max_events: Optional[int] = 50
     ) -> str:
         """Show me details for CRI-O Container issues generated in the last 45 min that had "high error rate" problem"""
         return f"""
         Get events:
-        {{
-            - Time range: {time_range or 'last 45 minutes'}
-            - Entity name: {entity_name or 'CRI-O Container'}
-            - Problem: {problem or 'high error rate'}
-            - Event type filters: {event_type_filters or '["ISSUE"]'}
-            - Max events: {max_events}
-        }}
+        - Time range: {time_range or 'last 45 minutes'}
+        - Entity name: {entity_name or 'CRI-O Container'}
+        - Problem: {problem or 'high error rate'}
+        - Event type filters: {event_type_filters or '["ISSUE"]'}
+        - Max events: {max_events}
         """
 
     @auto_register_prompt
@@ -104,18 +132,16 @@ class EventsPrompts:
     def get_events_by_entity_type_and_event_type(
         time_range: Optional[str] = None,
         entity_type: Optional[str] = None,
-        event_type_filters: Optional[list[str]] = None,
+        event_type_filters: Optional[List[str]] = None,
         max_events: Optional[int] = 50
     ) -> str:
         """Show me application incidents from the last week grouped by problem and sorted by severity"""
         return f"""
         Get events:
-        {{
-            - Time range: {time_range or 'last week'}
-            - Entity type: {entity_type or 'application'}
-            - Event type filters: {event_type_filters or '["INCIDENT"]'}
-            - Max events: {max_events}
-        }}
+        - Time range: {time_range or 'last week'}
+        - Entity type: {entity_type or 'application'}
+        - Event type filters: {event_type_filters or '["INCIDENT"]'}
+        - Max events: {max_events}
         """
 
     @auto_register_prompt
@@ -136,6 +162,7 @@ class EventsPrompts:
             ('get_event', cls.get_event),
             ('get_kubernetes_info_events', cls.get_kubernetes_info_events),
             ('get_agent_monitoring_events', cls.get_agent_monitoring_events),
+            ('get_events', cls.get_events),
             ('get_events_by_severity_and_state', cls.get_events_by_severity_and_state),
             ('get_events_by_entity_and_problem', cls.get_events_by_entity_and_problem),
             ('get_events_by_entity_type_and_event_type', cls.get_events_by_entity_type_and_event_type),

--- a/src/router/application_smart_router_tool.py
+++ b/src/router/application_smart_router_tool.py
@@ -70,7 +70,7 @@ CRITICAL WORKFLOW - ALWAYS FOLLOW THIS ORDER:
        - resource_type="catalog", operation="get_metric_catalog"
        - Returns: Available metrics with metricId, aggregations, and data sources
 
-    2. SECOND: Call get_tag_catalog to get valid tag names
+2. SECOND: Call get_tag_catalog to get valid tag names
        - resource_type="catalog", operation="get_tag_catalog"
        - params: {"use_case": "GROUPING", "data_source": "CALLS"}
 
@@ -93,6 +93,8 @@ METRICS (resource_type="metrics"):
     time_frame: {"to": <timestamp_or_datetime>, "windowSize": <milliseconds>}
         - to: Unix timestamp (ms) OR datetime string (e.g., "19 March 2026, 2:47 PM|IST")
         - windowSize: Duration in milliseconds (default: 3600000 = 1 hour)
+        - CRITICAL: Never pass "to": 0. Zero is Unix epoch (1970-01-01) and returns no data.
+          Omit "to" entirely when the user means "now", as "to" is OPTIONAL — the API defaults to the current time.
 
     tag_filter_expression: CRITICAL - Entity field is REQUIRED for ALL tag filters
 
@@ -167,6 +169,8 @@ ANALYZE (resource_type="analyze"):
         - to: Unix timestamp in milliseconds OR datetime string (e.g., "19 March 2026, 2:47 PM|IST")
         - If timezone not specified in datetime string, defaults to UTC
         - windowSize: Duration in milliseconds (default: 3600000 = 1 hour)
+        - CRITICAL: Never pass "to": 0. Zero is Unix epoch (1970-01-01) and returns no data.
+          Omit "to" entirely when the user means "now", as "to" is OPTIONAL — the API defaults to the current time.
 
     get_all_traces - params: {payload}
         payload: {timeFrame, includeInternal, includeSynthetic, tagFilterExpression, pagination, order}
@@ -240,9 +244,9 @@ Examples:
     resource_type="resources", operation="get_application_endpoints", params={"application_id": "app-123", "service_id": "svc-456", "endpoint_id": "ep-789", "name_filter": "/api/users", "types": ["HTTP"], "technologies": ["Java"]}
 
     # ANALYZE operations
-    resource_type="analyze", operation="get_all_traces", params={"payload": {"timeFrame": {"windowSize": 3600000, "to": 1710658800000}, "includeInternal": False, "includeSynthetic": False, "pagination": {"retrievalSize": 200}}}
+    resource_type="analyze", operation="get_all_traces", params={"payload": {"timeFrame": {"windowSize": 3600000}, "includeInternal": True, "includeSynthetic": False, "pagination": {"retrievalSize": 200}}}
     resource_type="analyze", operation="get_trace_details", params={"id": "trace-123", "retrievalSize": 100, "offset": 0, "ingestionTime": 1725519793}
-    resource_type="analyze", operation="get_trace_groups", params={"payload": {"group": {"groupbyTag": "trace.service.name", "groupbyTagEntity": "DESTINATION"}, "metrics": [{"metric": "traces", "aggregation": "SUM"}], "timeFrame": {"to": 1710658800000, "windowSize": 3600000}}}"""
+    resource_type="analyze", operation="get_trace_groups", params={"payload": {"group": {"groupbyTag": "trace.service.name", "groupbyTagEntity": "DESTINATION"},  "includeInternal": True, "includeSynthetic": False, "metrics": [{"metric": "traces", "aggregation": "SUM"}], "timeFrame": {"to": 1710658800000, "windowSize": 3600000}}}"""
     )
     async def manage_applications(
         self,
@@ -322,6 +326,12 @@ Examples:
         ctx
     ) -> Dict[str, Any]:
         """Handle application metrics queries."""
+        # Guard: "to": 0 means Unix epoch (1970), not "now". Strip it so the
+        # API defaults to the current server time, which is the correct behaviour
+        # when the user asks for a relative window like "last 1 hour".
+        if isinstance(params.get("time_frame"), dict) and params["time_frame"].get("to") == 0:
+            del params["time_frame"]["to"]
+
         # Convert datetime string for time_frame.to if provided
         conversion_result = convert_nested_datetime_param(
             params, "time_frame", "to", default_timezone="UTC"
@@ -705,6 +715,45 @@ Examples:
             logger.error(f"Error fetching application ID: {e}", exc_info=True)
             return {"error": f"Failed to fetch application ID: {e!s}"}
 
+    def _convert_analyze_time_params(
+        self, operation: str, params: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Convert datetime strings in analyze params in-place.
+        Returns an error dict if conversion fails, otherwise None.
+        """
+        # Convert datetime string for timeFrame.to in payload
+        payload = params.get("payload")
+        if isinstance(payload, dict):
+            time_frame = payload.get("timeFrame")
+            if isinstance(time_frame, dict):
+                # Guard: "to": 0 means Unix epoch (1970), not "now". Strip it so the
+                # API defaults to the current server time, which is the correct behaviour
+                # when the user asks for a relative window like "last 1 hour".
+                if time_frame.get("to") == 0:
+                    del time_frame["to"]
+                conversion_result = convert_nested_datetime_param(
+                    payload, "timeFrame", "to", default_timezone="UTC"
+                )
+                if "error" in conversion_result:
+                    return {"error": conversion_result["error"], "operation": operation, "resource_type": "analyze"}
+                params["payload"] = conversion_result["params"]
+
+        # Convert datetime string for ingestionTime in get_trace_details
+        if operation == "get_trace_details" and "ingestionTime" in params:
+            conversion_result = convert_datetime_param(
+                params["ingestionTime"],
+                "ingestionTime",
+                default_timezone="UTC",
+                output_unit="seconds"
+            )
+            if "error" in conversion_result:
+                return {"error": conversion_result["error"], "operation": operation, "resource_type": "analyze"}
+            if conversion_result["converted"]:
+                params["ingestionTime"] = conversion_result["value"]
+
+        return None
+
     async def _handle_analyze(
         self, operation: str, params: Dict[str, Any], ctx
     ) -> Dict[str, Any]:
@@ -725,38 +774,9 @@ Examples:
                 "message": f"Invalid operation '{operation}' for resource_type 'analyze'. Valid operations: {valid_operations}"
             }
 
-        # Convert datetime string for timeFrame.to in payload
-        if "payload" in params and isinstance(params.get("payload"), dict):
-            payload = params["payload"]
-            if "timeFrame" in payload and isinstance(payload.get("timeFrame"), dict):
-                conversion_result = convert_nested_datetime_param(
-                    payload, "timeFrame", "to", default_timezone="UTC"
-                )
-                if "error" in conversion_result:
-                    return {
-                        "error": conversion_result["error"],
-                        "operation": operation,
-                        "resource_type": "analyze"
-                    }
-                # Update payload with converted params
-                params["payload"] = conversion_result["params"]
-
-        # Convert datetime string for ingestionTime in get_trace_details
-        if operation == "get_trace_details" and "ingestionTime" in params:
-            conversion_result = convert_datetime_param(
-                params["ingestionTime"],
-                "ingestionTime",
-                default_timezone="UTC",
-                output_unit="seconds"
-            )
-            if "error" in conversion_result:
-                return {
-                    "error": conversion_result["error"],
-                    "operation": operation,
-                    "resource_type": "analyze"
-                }
-            if conversion_result["converted"]:
-                params["ingestionTime"] = conversion_result["value"]
+        time_error = self._convert_analyze_time_params(operation, params)
+        if time_error:
+            return time_error
 
         # Route to the analyze client with params
         result = await self.app_analyze_client.execute_analyze_operation(

--- a/src/router/events_smart_router_tool.py
+++ b/src/router/events_smart_router_tool.py
@@ -13,7 +13,7 @@ from mcp.types import ToolAnnotations
 
 from src.core.timestamp_utils import convert_datetime_params
 from src.core.utils import BaseInstanaClient, register_as_tool
-from src.core.validation import BooleanCoercer, EventsValidator, TimeValidator
+from src.core.validation import BooleanCoercer, EventsValidator
 
 logger = logging.getLogger(__name__)
 
@@ -190,20 +190,8 @@ class EventsSmartRouterMCPTool(BaseInstanaClient):
         self,
         operation: str,
         filters: Dict[str, Any],
-        from_time: Any,
-        to_time: Any,
     ) -> Optional[Dict[str, Any]]:
-        """Validate time params and max_events for time-requiring operations; return error dict or None."""
-        logger.debug(f"[manage_events] Validating time parameters for operation: {operation}")
-        time_validation = TimeValidator.validate_time_parameters(
-            from_time=from_time,
-            to_time=to_time,
-            time_range=filters[PARAM_TIME_RANGE],
-        )
-        if not time_validation.is_valid():
-            logger.warning(f"[manage_events] Time parameter validation failed for operation: {operation}, errors: {time_validation.to_dict()}")
-            return {"operation": operation, "validation_failed": True, **time_validation.to_dict()}
-
+        """Validate max_events for time-requiring operations; return error dict or None."""
         max_events_error = EventsValidator.validate_max_events(filters[PARAM_MAX_EVENTS])
         if max_events_error:
             logger.warning(f"[manage_events] max_events validation failed: {max_events_error.message}, provided value: {filters[PARAM_MAX_EVENTS]}")
@@ -267,6 +255,7 @@ Operations:
     - "get_events_by_ids": Get multiple events by their IDs
 
 Parameters (params dict):
+- MANDATORY: If NONE of from_time, to_time, or time_range are provided, defaults to the last 10 minutes
 - For "get_event" and "get_events_by_ids", pass flat params:
     - event_id: Event ID (required for get_event)
     - event_ids: List of event IDs or comma-separated string (required for get_events_by_ids)
@@ -275,7 +264,7 @@ Parameters (params dict):
         If timezone not specified in datetime string, defaults to UTC
     - to_time: End timestamp - milliseconds OR datetime string (e.g., "19 March 2026, 2:47 PM|IST" or "19 March 2026, 2:47 PM")
         If timezone not specified in datetime string, defaults to UTC
-    - time_range: Natural language time range like "last 24 hours", "last 2 days"
+    - time_range: Natural language time range (e.g., "last 10 minutes", "last 2 days"). DEFAULT when omitted: "last 10 minutes"
     - query: Optional query string for agent monitoring events
     - max_events: Maximum number of events to process for analysis (optional, default 50)
         NOTE: This is a post-processing limit, not an API parameter
@@ -283,7 +272,7 @@ Parameters (params dict):
     - filters: Dictionary containing event filters.
         - from_time: Start timestamp - milliseconds OR datetime string
         - to_time: End timestamp - milliseconds OR datetime string
-        - time_range: Natural language time range like "last 24 hours", "last 2 days"
+        - time_range: Natural language time range (e.g., "last 10 minutes", "last 2 days"). DEFAULT when omitted: "last 10 minutes"
         - query: Optional query string
         - max_events: Maximum number of events to process for analysis (optional, default 50)
         - filter_event_updates: Boolean flag to filter results to only show events with state changes within timeframe (optional, default True)
@@ -323,9 +312,10 @@ Returns:
 
 Examples:
     operation="get_event", params={"event_id": "1a2b3c4d5e6f"}
-    operation="get_kubernetes_info_events", params={"time_range": "last 24 hours", "max_events": 50}
+    operation="get_kubernetes_info_events", params={"time_range": "last 2 hours", "max_events": 50}
     operation="get_agent_monitoring_events", params={"query": "Monitoring issue", "from_time": "19 March 2026, 2:47 PM|IST", "to_time": "20 March 2026, 2:47 PM|IST", "max_events": 100}
-    operation="get_events", params={"filters": {"time_range": "last 24 hours", "event_type_filters": ["INCIDENT"], "entity_type": "service", "entity_name": "payment-service", "entity_label": "payment-service-v2", "state": "open", "problem": "High error rate", "severity": 10, "max_events": 50, "filter_event_updates": True, "exclude_triggered_before": False}}
+    operation="get_events", params={"filters": {"event_type_filters": ["INCIDENT"]}}  # no time_range → defaults to last 10 minutes
+    operation="get_events", params={"filters": {"event_type_filters": ["INCIDENT"], "entity_type": "service", "entity_name": "payment-service", "entity_label": "payment-service-v2", "state": "open", "problem": "High error rate", "severity": 10, "max_events": 50, "filter_event_updates": True, "exclude_triggered_before": False}}
     operation="get_events_by_ids", params={"event_ids": ["1a2b3c4d5e6f", "7g8h9i0j1k2l"]}"""
     )
     async def manage_events(
@@ -376,7 +366,7 @@ Examples:
             to_time = conversion_result["params"][PARAM_TO_TIME]
 
             if operation in TIME_REQUIRED_OPERATIONS:
-                time_error = self._validate_time_and_max_events(operation, filters, from_time, to_time)
+                time_error = self._validate_time_and_max_events(operation, filters)
                 if time_error:
                     return time_error
 

--- a/tests/e2e/event/test_events_tools.py
+++ b/tests/e2e/event/test_events_tools.py
@@ -962,7 +962,7 @@ class TestAgentMonitoringEventsE2E:
             # Test with no parameters (should use defaults)
             from_time, to_time = client._process_time_range()
             assert to_time == 1625097900000  # Current time in ms
-            assert from_time == to_time - (24 * 60 * 60 * 1000)  # 24 hours before
+            assert from_time == to_time - (10 * 60 * 1000)  # 10 minutes before
 
             # Test with only from_time
             custom_from = 1625000000000
@@ -974,7 +974,7 @@ class TestAgentMonitoringEventsE2E:
             custom_to = 1625090000000
             from_time, to_time = client._process_time_range(to_time=custom_to)
             assert to_time == custom_to
-            assert from_time == custom_to - (24 * 60 * 60 * 1000)
+            assert from_time == custom_to - (10 * 60 * 1000)
 
             # Test with both from_time and to_time
             custom_from = 1625000000000
@@ -986,7 +986,7 @@ class TestAgentMonitoringEventsE2E:
             # Test with "last few hours"
             from_time, to_time = client._process_time_range(time_range="last few hours")
             assert to_time == 1625097900000
-            assert from_time == to_time - (24 * 60 * 60 * 1000)
+            assert from_time == to_time - (10 * 60 * 1000)
 
             # Test with "last 12 hours"
             from_time, to_time = client._process_time_range(time_range="last 12 hours")
@@ -1011,7 +1011,7 @@ class TestAgentMonitoringEventsE2E:
             # Test with unknown format
             from_time, to_time = client._process_time_range(time_range="unknown format")
             assert to_time == 1625097900000
-            assert from_time == to_time - (24 * 60 * 60 * 1000)
+            assert from_time == to_time - (10 * 60 * 1000)
 
             # Test with time_range overriding from_time and to_time
             custom_from = 1625000000000
@@ -1176,7 +1176,7 @@ class TestAgentMonitoringEventsE2E:
         assert to_time == test_to_time
         assert isinstance(from_time, int)
         assert to_time > from_time
-        assert to_time - from_time == 24 * 60 * 60 * 1000  # 24 hours
+        assert to_time - from_time == 10 * 60 * 1000  # 10 minutes
 
         # Test with both from_time and to_time
         test_from_time = 1625097600000
@@ -1442,7 +1442,7 @@ class TestAgentMonitoringEventsE2E:
         assert isinstance(from_time, int)
         assert isinstance(to_time, int)
         assert to_time > from_time
-        assert to_time - from_time == 24 * 60 * 60 * 1000  # 24 hours
+        assert to_time - from_time == 10 * 60 * 1000  # 10 minutes
 
         # Test with "last 12 hours"
         from_time, to_time = client._process_time_range(time_range="last 12 hours")
@@ -1459,14 +1459,14 @@ class TestAgentMonitoringEventsE2E:
         assert to_time - from_time == 3 * 24 * 60 * 60 * 1000  # 3 days
 
         # Test with "last week" - "last week" contains "week" but no number, so no match
-        # falls through to default 24 hours
+        # falls through to default 10 minutes
         from_time, to_time = client._process_time_range(time_range="last week")
         assert isinstance(from_time, int)
         assert isinstance(to_time, int)
         assert to_time > from_time
         # "last week" has no digit before "week", so _convert_time_range_to_window_size
-        # falls through to default 24 hours
-        assert to_time - from_time == 24 * 60 * 60 * 1000  # default 24 hours
+        # falls through to default 10 minutes
+        assert to_time - from_time == 10 * 60 * 1000  # default 10 minutes
 
         # Test with "last 2 weeks"
         from_time, to_time = client._process_time_range(time_range="last 2 weeks")
@@ -1476,14 +1476,14 @@ class TestAgentMonitoringEventsE2E:
         assert to_time - from_time == 2 * 7 * 24 * 60 * 60 * 1000  # 2 weeks
 
         # Test with "last month" - "last month" has no digit, so no regex match
-        # falls through to default 24 hours
+        # falls through to default 10 minutes
         from_time, to_time = client._process_time_range(time_range="last month")
         assert isinstance(from_time, int)
         assert isinstance(to_time, int)
         assert to_time > from_time
         # "last month" has no digit before "month", so _convert_time_range_to_window_size
-        # falls through to default 24 hours
-        assert to_time - from_time == 24 * 60 * 60 * 1000  # default 24 hours
+        # falls through to default 10 minutes
+        assert to_time - from_time == 10 * 60 * 1000  # default 10 minutes
 
         # Test with "last 2 months"
         from_time, to_time = client._process_time_range(time_range="last 2 months")

--- a/tests/event/test_events_tools.py
+++ b/tests/event/test_events_tools.py
@@ -281,9 +281,9 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
         result = asyncio.run(self.client.get_kubernetes_info_events())
 
         # Check that the mock was called with the correct arguments
-        # When no time params provided, _build_time_params uses var_from/to (default 24h window)
+        # When no time params provided, _build_time_params uses var_from/to (default 10 min window)
         expected_to_time = 1000 * 1000  # Convert seconds to milliseconds
-        expected_from_time = expected_to_time - (24 * 60 * 60 * 1000)  # 24 hours earlier
+        expected_from_time = expected_to_time - (10 * 60 * 1000)  # 10 minutes earlier
 
         self.events_api.kubernetes_info_events.assert_called_once_with(
             var_from=expected_from_time,
@@ -409,9 +409,9 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
         result = asyncio.run(self.client.get_agent_monitoring_events())
 
         # Check that the mock was called with the correct arguments
-        # When no time params provided, _build_time_params uses var_from/to (default 24h window)
+        # When no time params provided, _build_time_params uses var_from/to (default 10 min window)
         expected_to_time = 1000 * 1000  # Convert seconds to milliseconds
-        expected_from_time = expected_to_time - (24 * 60 * 60 * 1000)  # 24 hours earlier
+        expected_from_time = expected_to_time - (10 * 60 * 1000)  # 10 minutes earlier
 
         self.events_api.agent_monitoring_events.assert_called_once_with(
             var_from=expected_from_time,
@@ -517,12 +517,12 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
 
         # Expected window sizes for each time range (used when time_range is provided)
         expected_window_sizes = [
-            24 * 60 * 60 * 1000,           # last few hours -> default 24 hours
+            10 * 60 * 1000,                # last few hours -> default 10 minutes
             5 * 60 * 60 * 1000,            # last 5 hours
             3 * 24 * 60 * 60 * 1000,       # last 3 days
             2 * 7 * 24 * 60 * 60 * 1000,   # last 2 weeks
             1 * 30 * 24 * 60 * 60 * 1000,  # last 1 month
-            24 * 60 * 60 * 1000            # unknown format -> default 24 hours (still uses window_size)
+            10 * 60 * 1000                 # unknown format -> default 10 minutes (still uses window_size)
         ]
 
         for i, time_range in enumerate(time_ranges):
@@ -767,9 +767,9 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
             # Call the method with unusual time range
             result_from_time, result_to_time = self.client._process_time_range("last century", None, None)
 
-            # Check that default values were used (24 hours)
+            # Check that default values were used (10 minutes)
             expected_to_time = 1000 * 1000  # Convert seconds to milliseconds
-            expected_from_time = expected_to_time - (24 * 60 * 60 * 1000)  # 24 hours earlier
+            expected_from_time = expected_to_time - (10 * 60 * 1000)  # 10 minutes earlier
 
             self.assertEqual(result_from_time, expected_from_time)
             self.assertEqual(result_to_time, expected_to_time)
@@ -848,12 +848,12 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
             # Result not needed as we're checking the mock call
             _ = asyncio.run(self.client.get_agent_monitoring_events(to_time=to_time))
 
-            # Check that from_time was set to 1 hour before to_time
+            # Check that from_time was set to 10 minutes before to_time
             self.events_api.agent_monitoring_events.assert_called_once()
             call_args = self.events_api.agent_monitoring_events.call_args[1]
             self.assertEqual(call_args['to'], to_time)
-            # The default from_time is 24 hours before to_time, not 1 hour
-            self.assertEqual(call_args['var_from'], to_time - (24 * 60 * 60 * 1000))  # 24 hours in milliseconds
+            # The default from_time is 10 minutes before to_time
+            self.assertEqual(call_args['var_from'], to_time - (10 * 60 * 1000))  # 10 minutes in milliseconds
 
     def test_get_agent_monitoring_events_with_non_dict_event(self):
         """Test get_agent_monitoring_events with non-dictionary event"""
@@ -1036,9 +1036,9 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
             # Call the method with 'few hours' format
             from_time, to_time = self.client._process_time_range("last few hours", None, None)
 
-            # Check that default values were used (24 hours)
+            # Check that default values were used (10 minutes)
             expected_to_time = 1000 * 1000  # Convert seconds to milliseconds
-            expected_from_time = expected_to_time - (24 * 60 * 60 * 1000)  # 24 hours earlier
+            expected_from_time = expected_to_time - (10 * 60 * 1000)  # 10 minutes earlier
 
             self.assertEqual(from_time, expected_from_time)
             self.assertEqual(to_time, expected_to_time)
@@ -1055,8 +1055,8 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
             to_time_value = 500000
             from_time, to_time = self.client._process_time_range(None, None, to_time_value)
 
-            # Check that from_time was set to 24 hours before to_time
-            expected_from_time = to_time_value - (24 * 60 * 60 * 1000)  # 24 hours earlier
+            # Check that from_time was set to 10 minutes before to_time
+            expected_from_time = to_time_value - (10 * 60 * 1000)  # 10 minutes earlier
 
             self.assertEqual(from_time, expected_from_time)
             self.assertEqual(to_time, to_time_value)
@@ -1595,16 +1595,15 @@ class TestAgentMonitoringEventsMCPTools(unittest.TestCase):
         self.assertEqual(result["affectedMetrics"], ["errors", "latency"])
 
     def test_build_time_params_with_invalid_time_range(self):
-        """Test _build_time_params with invalid time_range falls back to defaults."""
-        # Mock _convert_time_range_to_window_size to return None
-        with patch.object(self.client, '_convert_time_range_to_window_size', return_value=None):
-            result = self.client._build_time_params(time_range="invalid time range")
+        """Test _build_time_params with an unrecognised time_range uses the default window_size."""
+        # _convert_time_range_to_window_size always returns a value (defaults to 10 minutes)
+        # so api_params receives window_size, not var_from/to
+        result = self.client._build_time_params(time_range="invalid time range")
 
-            self.assertIn("api_params", result)
-            self.assertIn("var_from", result["api_params"])
-            self.assertIn("to", result["api_params"])
-            self.assertIn("from_time", result)
-            self.assertIn("to_time", result)
+        self.assertIn("api_params", result)
+        self.assertIn("window_size", result["api_params"])
+        self.assertIn("from_time", result)
+        self.assertIn("to_time", result)
 
     def test_extract_event_filters_returns_only_allowed_keys(self):
         """_extract_event_filters should whitelist keys and apply defaults."""

--- a/tests/prompts/events/test_events_tools.py
+++ b/tests/prompts/events/test_events_tools.py
@@ -54,12 +54,13 @@ class TestEventsPrompts(unittest.TestCase):
         """Test that get_prompts returns all prompts defined in the class."""
         prompts = EventsPrompts.get_prompts()
         # There are now 7 prompts in the EventsPrompts class
-        self.assertEqual(len(prompts), 7)
+        self.assertEqual(len(prompts), 8)
         self.assertEqual(prompts[0][0], 'get_event')
         self.assertEqual(prompts[1][0], 'get_kubernetes_info_events')
         self.assertEqual(prompts[2][0], 'get_agent_monitoring_events')
-        self.assertEqual(prompts[3][0], 'get_events_by_severity_and_state')
-        self.assertEqual(prompts[4][0], 'get_events_by_entity_and_problem')
+        self.assertEqual(prompts[3][0], 'get_events')
+        self.assertEqual(prompts[4][0], 'get_events_by_severity_and_state')
+        self.assertEqual(prompts[5][0], 'get_events_by_entity_and_problem')
 
     def test_get_event_prompt_content(self):
         """Test that get_event returns expected prompt content."""
@@ -135,7 +136,13 @@ class TestEventsPrompts(unittest.TestCase):
         for name, prompt_func in prompts:
             if name == "get_event":
                 result = prompt_func(event_id="test")
-            elif name in {"get_kubernetes_info_events", "get_agent_monitoring_events", "get_events_by_severity_and_state", "get_events_by_entity_and_problem", "get_events_by_entity_type_and_event_type"}:
+            elif name in {
+                "get_kubernetes_info_events",
+                "get_agent_monitoring_events",
+                "get_events_by_severity_and_state",
+                "get_events_by_entity_and_problem",
+                "get_events_by_entity_type_and_event_type",
+            }:
                 result = prompt_func()
             elif name == "get_events_by_ids":
                 result = prompt_func(event_ids=["test"])

--- a/tests/router/test_events_smart_router_tool.py
+++ b/tests/router/test_events_smart_router_tool.py
@@ -321,15 +321,19 @@ class TestEventsSmartRouterMCPTool(unittest.TestCase):
 
         self.assertTrue(captured["filters"]["rca"])
 
-    def test_get_events_time_validation_fails_without_time_params(self):
-        """get_events without any time params should fail time validation."""
+    def test_get_events_without_time_params_uses_defaults(self):
+        """get_events without any time params should succeed and use defaults."""
+        async def mock_get_events(*args, **kwargs):
+            return {"events": [], "events_returned": 0, "total_events": 0}
+
+        self.mock_events.get_events = mock_get_events
+
         result = asyncio.run(self.router.manage_events(
             operation="get_events",
             params={"filters": {}}
         ))
 
-        self.assertIn("validation_failed", result)
-        self.assertTrue(result["validation_failed"])
+        self.assertIn("results", result)
 
     def test_get_events_exception_handling(self):
         """get_events should return an error dict when events client raises."""


### PR DESCRIPTION
## Summary

This PR changes the default event time window from 24 hours to 10 minutes and removes the requirement to explicitly provide a time filter when querying events.

It also adds a dedicated `get_events` prompt, improves the `manage_events` documentation, and includes a small refactor in the application analyze handler.

## Changes

### Events

- Changed the default event time window from 24 hours to 10 minutes.
- Removed mandatory time parameter validation; requests without a time filter now automatically use the default 10-minute window.
- Updated the `manage_events` documentation to clearly explain the default time window and how to narrow event queries.
- Added a dedicated `get_events` prompt with support for the available event filters.

### Application Analyze

- Extracted duplicated time parameter conversion logic into a reusable helper.
- Added handling for `"to": 0` to avoid passing the Unix epoch sentinel.
- Updated relevant documentation examples.

### Testing

Updated unit, E2E, prompt, and router tests to reflect:

- The new 10-minute default time window.
- Removal of mandatory time validation.
- Registration of the new `get_events` prompt.