### PR TITLE
fix: remove redundant uv install and fix healthcheck response parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,6 @@ COPY pyproject.toml pyproject.toml
 COPY src ./src
 COPY README.md ./
 
-# Install uv for dependency management
-RUN pip install --no-cache-dir uv
-
 # Install runtime dependencies
 RUN pip install --no-cache-dir .
 
@@ -63,7 +60,8 @@ req = urllib.request.Request( \
     headers={'Content-Type':'application/json','Accept':'application/json, text/event-stream'}, \
     method='POST'); \
 resp = urllib.request.urlopen(req, timeout=5).read().decode(); \
-sys.exit(0 if 'serverInfo' in resp else 1)" || exit 1
+data = json.loads(resp); \
+sys.exit(0 if 'result' in data and 'serverInfo' in data['result'] else 1)" || exit 1
 
 # Run the server
 ENTRYPOINT ["python", "-m", "src.core.server"]

--- a/build_multiplatform.sh
+++ b/build_multiplatform.sh
@@ -73,7 +73,7 @@ detect_os() {
     case "$uname_out" in
         Darwin*)  HOST_OS="mac"     ;;
         Linux*)
-            if [[ -n "${WSLENV:-}" || -f /proc/version ]] && grep -qi "microsoft\|wsl" /proc/version 2>/dev/null; then
+            if [[ -n "${WSLENV:-}" ]] || grep -qi "microsoft\|wsl" /proc/version 2>/dev/null; then
                 HOST_OS="windows"   # WSL2
             else
                 HOST_OS="linux"
@@ -165,7 +165,7 @@ if [ "$ENGINE_TYPE" = "podman" ]; then
             podman manifest add "$MANIFEST_NAME" "$ARCH_TAG"
         done
 
-        podman manifest push "$MANIFEST_NAME" "docker://$MANIFEST_NAME"
+        podman manifest push "$MANIFEST_NAME" "docker://$MANIFEST_NAME" || { echo "Push failed!"; exit 1; }
 
         echo "Multi-architecture image pushed as: $FULL_IMAGE_NAME"
         echo "Verifying manifest..."


### PR DESCRIPTION

## Changes

#### `Dockerfile`
- **Removed redundant `uv` install step** — `uv` was being installed via pip but is not used for the actual dependency installation (`pip install .` is used directly). This reduces the image build time and layer count.
- **Fixed healthcheck response parsing** — The healthcheck inline Python script previously checked for `'serverInfo'` anywhere in the raw response string. It now properly parses the JSON and checks `data['result']['serverInfo']`, aligning with the actual MCP SSE/JSON-RPC response structure.

#### `build_multiplatform.sh`
- **Fixed WSL2 detection logic** — The original condition used `&&` which required both `WSLENV` being set AND a matching `/proc/version` entry. Changed to `||` so either condition alone correctly identifies a WSL2 environment.
- **Added error handling for `podman manifest push`** — The push command now fails fast with a clear error message (`Push failed!; exit 1`) if the manifest push does not succeed, preventing silent failures in CI.