### PR TITLE
fix(maintenance-window): scope no-active counts and message to requested application

### DIFF
--- a/src/maintenance_window/maintenance_window_tool.py
+++ b/src/maintenance_window/maintenance_window_tool.py
@@ -1578,16 +1578,22 @@ class MaintenanceWindowMCPTools(BaseInstanaClient):
         application_id: Optional[str]
     ) -> Dict[str, Any]:
         """Build response when no active windows found."""
-        expired_count = sum(1 for w in all_windows if w.get("state") == "EXPIRED")
-        scheduled_count = sum(1 for w in all_windows if w.get("state") == "SCHEDULED")
+        if application_id:
+            relevant = [w for w in all_windows if self._matches_application_filter(w, application_id)]
+        else:
+            relevant = all_windows
 
+        expired_count = sum(1 for w in relevant if w.get("state") == "EXPIRED")
+        scheduled_count = sum(1 for w in relevant if w.get("state") == "SCHEDULED")
+
+        scope = f" for '{application_id}'" if application_id else ""
         return {
             "operation": "list_active",
             "status": "success",
             "count": 0,
             "windows": [],
             "application_id": application_id,
-            "message": f"No active maintenance windows found. Found {expired_count} expired and {scheduled_count} scheduled windows.",
+            "message": f"No active maintenance windows found{scope}. Found {expired_count} expired and {scheduled_count} scheduled windows{scope}.",
             "suggestion": "Use operation 'list_expired' to see expired windows or 'list_all' to see all windows.",
             "expired_count": expired_count,
             "scheduled_count": scheduled_count


### PR DESCRIPTION

When listing active maintenance windows filtered by application_id, the "no active windows found" response was incorrectly reporting counts of expired and scheduled windows across all applications, not just the filtered one. This gave misleading feedback. e.g. reporting 10 expired windows when none of them belonged to the requested application. In _build_no_active_windows_response, the expired and scheduled window counts are now filtered to only include windows matching the requested application_id. The response message also includes the application scope (e.g. "No active maintenance windows found for 'my-app'") so it's clear the result is scoped and not global.

